### PR TITLE
Fix x86_64 SIMD build and test all three SIMD paths in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,40 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # `.cargo/config.toml` sets `-C target-cpu=native`, which is right for local
-  # benchmarking but bakes host-specific instructions into CI artifacts.
-  RUSTFLAGS: "-D warnings"
 
 jobs:
+  # The SIMD kernels are #[cfg]-gated per architecture and per target-feature,
+  # so a single runner only ever compiles one of them. Each entry below is the
+  # only place its kernel gets type-checked and linted at all.
   check:
-    name: fmt / clippy / test
-    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64 (sse)
+            os: ubuntu-latest
+            flags: ""
+          - name: x86_64 (avx+fma)
+            os: ubuntu-latest
+            flags: "-C target-feature=+avx,+fma"
+          - name: aarch64 (neon)
+            os: macos-latest
+            flags: ""
+    env:
+      # Setting RUSTFLAGS replaces `.cargo/config.toml`'s `[build] rustflags`,
+      # which is what we want: `-C target-cpu=native` is right for local
+      # benchmarking but bakes host-specific instructions into CI artifacts.
+      RUSTFLAGS: "-D warnings ${{ matrix.flags }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.name }}
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -37,11 +57,19 @@ jobs:
   blas:
     name: openblas backend
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: openblas
       - name: Install OpenBLAS
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev gfortran
-      - name: Build and test with BLAS
+      - name: Clippy
+        run: cargo clippy --features blas-openblas --all-targets -- -D warnings
+      - name: Test
         run: cargo test --features blas-openblas --all-targets

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -4,8 +4,6 @@ use std::sync::{RwLockReadGuard, RwLockWriteGuard, atomic::Ordering};
 
 use rayon::prelude::*;
 
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
 use std::sync::{Arc, RwLock};
 
 // SIMD utility module for cross-platform support
@@ -75,10 +73,11 @@ pub mod simd {
         let chunks = a.len() / 8;
         for i in 0..chunks {
             let idx = i * 8;
-            let va = _mm256_loadu_ps(a.as_ptr().add(idx));
-            let vb = _mm256_loadu_ps(b.as_ptr().add(idx));
-            let result = _mm256_add_ps(va, vb);
-            _mm256_storeu_ps(out.as_mut_ptr().add(idx), result);
+            unsafe {
+                let va = _mm256_loadu_ps(a.as_ptr().add(idx));
+                let vb = _mm256_loadu_ps(b.as_ptr().add(idx));
+                _mm256_storeu_ps(out.as_mut_ptr().add(idx), _mm256_add_ps(va, vb));
+            }
         }
         // Handle remainder
         for i in (chunks * 8)..a.len() {
@@ -92,10 +91,11 @@ pub mod simd {
         let chunks = a.len() / 4;
         for i in 0..chunks {
             let idx = i * 4;
-            let va = _mm_loadu_ps(unsafe { a.as_ptr().add(idx) });
-            let vb = _mm_loadu_ps(unsafe { b.as_ptr().add(idx) });
-            let result = _mm_add_ps(va, vb);
-            _mm_storeu_ps(unsafe { out.as_mut_ptr().add(idx) }, result);
+            unsafe {
+                let va = _mm_loadu_ps(a.as_ptr().add(idx));
+                let vb = _mm_loadu_ps(b.as_ptr().add(idx));
+                _mm_storeu_ps(out.as_mut_ptr().add(idx), _mm_add_ps(va, vb));
+            }
         }
         // Handle remainder
         for i in (chunks * 4)..a.len() {
@@ -170,10 +170,11 @@ pub mod simd {
         let chunks = a.len() / 8;
         for i in 0..chunks {
             let idx = i * 8;
-            let va = _mm256_loadu_ps(a.as_ptr().add(idx));
-            let vb = _mm256_loadu_ps(b.as_ptr().add(idx));
-            let result = _mm256_mul_ps(va, vb);
-            _mm256_storeu_ps(out.as_mut_ptr().add(idx), result);
+            unsafe {
+                let va = _mm256_loadu_ps(a.as_ptr().add(idx));
+                let vb = _mm256_loadu_ps(b.as_ptr().add(idx));
+                _mm256_storeu_ps(out.as_mut_ptr().add(idx), _mm256_mul_ps(va, vb));
+            }
         }
         for i in (chunks * 8)..a.len() {
             out[i] = a[i] * b[i];
@@ -186,10 +187,11 @@ pub mod simd {
         let chunks = a.len() / 4;
         for i in 0..chunks {
             let idx = i * 4;
-            let va = _mm_loadu_ps(unsafe { a.as_ptr().add(idx) });
-            let vb = _mm_loadu_ps(unsafe { b.as_ptr().add(idx) });
-            let result = _mm_mul_ps(va, vb);
-            _mm_storeu_ps(unsafe { out.as_mut_ptr().add(idx) }, result);
+            unsafe {
+                let va = _mm_loadu_ps(a.as_ptr().add(idx));
+                let vb = _mm_loadu_ps(b.as_ptr().add(idx));
+                _mm_storeu_ps(out.as_mut_ptr().add(idx), _mm_mul_ps(va, vb));
+            }
         }
         for i in (chunks * 4)..a.len() {
             out[i] = a[i] * b[i];


### PR DESCRIPTION
The SSE/AVX kernels never compiled on aarch64, so an unused intrinsics import and edition-2024 unsafe_op_in_unsafe_fn violations reached CI unnoticed. CI only ever built the SSE path; the matrix now covers x86_64 baseline, x86_64 +avx,+fma and aarch64 NEON, which is the only way these cfg-gated kernels get checked.