### PR TITLE
Link the BLAS vendor library so blas-openblas actually builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+// `blas-src` carries the native link directives for the selected BLAS vendor,
+// but it exports no items we call — we go through `cblas-sys` instead. Without
+// an explicit reference rustc drops it as an unused dependency and its
+// `-l` flags go with it, so the build gets the library's search path but never
+// links it: `undefined symbol: cblas_sgemm`.
+#[cfg(feature = "blas")]
+use blas_src as _;
+
 pub mod activation;
 pub mod data;
 pub mod gemm;


### PR DESCRIPTION
Nothing referenced blas-src, so rustc dropped it as an unused dependency and its native -l flags went with it: the link line carried OpenBLAS's search path but never -lopenblas, failing with `undefined symbol: cblas_sgemm`. The feature has never linked; adding a CI job for it is what surfaced this.