### PR TITLE
strided tensors — reshape, transpose and slicing become views

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -50,6 +50,8 @@ mod imp {
         }
     }
 
+    pub type TransFlag = CBLAS_TRANSPOSE;
+
     #[inline]
     pub fn n() -> CBLAS_TRANSPOSE {
         CBLAS_TRANSPOSE::CblasNoTrans
@@ -120,6 +122,8 @@ mod imp {
         }
     }
 
+    pub type TransFlag = Trans;
+
     #[inline]
     pub fn n() -> Trans {
         Trans::N
@@ -130,4 +134,4 @@ mod imp {
     }
 }
 
-pub use imp::{n, sgemm_rowmajor, t};
+pub use imp::{TransFlag, n, sgemm_rowmajor, t};

--- a/src/loss.rs
+++ b/src/loss.rs
@@ -5,8 +5,8 @@ use crate::{Tensor, ops};
 /// L = -mean( y*log(p) + (1-y)*log(1-p) )
 pub fn bce_loss(predictions: &Tensor, targets: &Tensor) -> Tensor {
     let eps: f32 = 1e-7;
-    let p = predictions.data();
-    let t = targets.data();
+    let p = predictions.elements();
+    let t = targets.elements();
     assert_eq!(
         p.len(),
         t.len(),
@@ -35,8 +35,8 @@ pub fn bce_loss(predictions: &Tensor, targets: &Tensor) -> Tensor {
             if let Some(gout) = out_clone.grad.read().unwrap().as_ref() {
                 let g = gout[0]; // scalar chain multiplier from upstream
 
-                let pdat = preds.data();
-                let tdat = targs.data();
+                let pdat = preds.elements();
+                let tdat = targs.elements();
 
                 // dL/dp_i = -( y/p - (1-y)/(1-p) ) / N
                 if preds.requires_grad {
@@ -157,8 +157,8 @@ pub fn cross_entropy_loss(logits: &Tensor, targets: &Tensor) -> Tensor {
 
     // log p = log_softmax(logits)
     let logp = log_softmax(logits, -1);
-    let lp = logp.data();
-    let t = targets.data();
+    let lp = logp.elements();
+    let t = targets.elements();
 
     // NLL loss (mean)
     let mut acc = 0.0f32;

--- a/src/nn.rs
+++ b/src/nn.rs
@@ -854,7 +854,7 @@ impl Module for Dropout {
         }
 
         if self.p == 1.0 {
-            return Tensor::new(vec![0.0; input.data().len()], input.shape());
+            return Tensor::new(vec![0.0; input.numel()], input.shape());
         }
 
         // Create dropout mask
@@ -884,39 +884,6 @@ impl Module for Dropout {
 
 // Helper implementations for tensor operations needed by grouped convolution
 impl Tensor {
-    /// Gather `indices` (flat positions into this tensor) into a new tensor of
-    /// `out_shape`, recording a scatter-add backward edge.
-    ///
-    /// All the slicing helpers below reduce to this. Previously they built
-    /// their outputs with a bare `Tensor::new`, which left grouped convolution
-    /// with no path back to its weights: `Conv2d` with `groups > 1` trained
-    /// forever without ever updating a parameter.
-    fn gather_flat(&self, indices: Vec<usize>, out_shape: &[usize]) -> Tensor {
-        let data = self.data();
-        let result_data: Vec<f32> = indices.iter().map(|&i| data[i]).collect();
-        drop(data);
-
-        let mut output = Tensor::new(result_data, out_shape);
-
-        if self.requires_grad {
-            output.requires_grad = true;
-            let input = self.clone();
-            let out = output.clone();
-
-            crate::tape::Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
-                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
-                    let gin = slot.get_or_insert_with(|| vec![0.0; input.numel()]);
-                    for (&src_idx, &g) in indices.iter().zip(gout.iter()) {
-                        gin[src_idx] += g;
-                    }
-                }
-            });
-        }
-
-        output
-    }
-
     /// Extract a slice of channels from a 4D tensor
     pub fn slice_channels(&self, start: usize, end: usize) -> Tensor {
         assert_eq!(
@@ -926,18 +893,7 @@ impl Tensor {
         );
         assert!(start < end && end <= self.shape[1], "Invalid channel range");
 
-        let (n, c, h, w) = (self.shape[0], self.shape[1], self.shape[2], self.shape[3]);
-        let c_slice = end - start;
-
-        let mut indices = Vec::with_capacity(n * c_slice * h * w);
-        for batch in 0..n {
-            for ch in start..end {
-                let base_idx = batch * c * h * w + ch * h * w;
-                indices.extend(base_idx..base_idx + h * w);
-            }
-        }
-
-        self.gather_flat(indices, &[n, c_slice, h, w])
+        self.narrow(1, start, end - start)
     }
 
     /// Extract output channels from weight tensor
@@ -952,13 +908,7 @@ impl Tensor {
             "Invalid output channel range"
         );
 
-        let (_c_out, c_in, k_h, k_w) = (self.shape[0], self.shape[1], self.shape[2], self.shape[3]);
-        let c_out_slice = end - start;
-        let per_filter = c_in * k_h * k_w;
-
-        let indices: Vec<usize> = (start * per_filter..end * per_filter).collect();
-
-        self.gather_flat(indices, &[c_out_slice, c_in, k_h, k_w])
+        self.narrow(0, start, end - start)
     }
 
     /// Extract slice from 1D tensor (for bias)
@@ -966,7 +916,7 @@ impl Tensor {
         assert_eq!(self.shape.len(), 1, "slice_1d only works on 1D tensors");
         assert!(start < end && end <= self.shape[0], "Invalid range");
 
-        self.gather_flat((start..end).collect(), &[end - start])
+        self.narrow(0, start, end - start)
     }
 
     /// Concatenate tensors along specified dimension
@@ -1019,7 +969,7 @@ impl Tensor {
         for o in 0..outer {
             for (ti, tensor) in tensors.iter().enumerate() {
                 let block = tensor.shape[dim] * inner;
-                let data = tensor.data();
+                let data = tensor.elements();
                 let start = o * block;
                 for &v in &data[start..start + block] {
                     source_positions[ti].push(result_data.len());

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,23 @@
-use crate::gemm::{n as no_trans, sgemm_rowmajor, t as trans};
+use crate::gemm::{TransFlag, n as no_trans, sgemm_rowmajor, t as trans};
+use crate::tensor::GemmLayout;
 use crate::{Tensor, tape::Tape};
 use std::ops::{Add, Div, Mul, Sub};
+
+/// The GEMM trans flag that makes `operand` present as `op(X) = Xᵀ` when
+/// `want_transpose`, or as `X` otherwise.
+///
+/// A tensor stored transposed already *is* its own transpose in memory, so the
+/// two conditions cancel: the flag is `T` exactly when they disagree. This one
+/// rule covers the forward product and both backward products.
+#[inline]
+fn trans_flag(operand: &Tensor, want_transpose: bool) -> TransFlag {
+    let stored_transposed = matches!(operand.gemm_layout_2d(), Some(GemmLayout::Transposed));
+    if stored_transposed != want_transpose {
+        trans()
+    } else {
+        no_trans()
+    }
+}
 
 // Import the SIMD utilities from tensor module
 use crate::tensor::simd;
@@ -10,12 +27,8 @@ impl Add for &Tensor {
     fn add(self, other: &Tensor) -> Tensor {
         assert_same_shape(self, other, "add");
 
-        // Clone data ONCE at the start
-        let (a_data, b_data) = {
-            let a = self.data();
-            let b = other.data();
-            (a.clone(), b.clone())
-        };
+        let a_data = self.elements();
+        let b_data = other.elements();
         let mut out_data = vec![0.0; a_data.len()];
 
         // Use SIMD operations
@@ -54,8 +67,8 @@ impl Mul for &Tensor {
     fn mul(self, other: &Tensor) -> Tensor {
         assert_same_shape(self, other, "mul");
 
-        let self_data = self.data();
-        let other_data = other.data();
+        let self_data = self.elements();
+        let other_data = other.elements();
         let mut out_data = vec![0.0; self_data.len()];
 
         // Use SIMD operations
@@ -77,7 +90,7 @@ impl Mul for &Tensor {
                     // gradient from the *other* operand's data and round-trip
                     // through two scratch buffers; fold it into one pass.
                     if a.requires_grad {
-                        let bdat = b.data();
+                        let bdat = b.elements();
                         let mut slot = a.grad.write().expect("grad RwLock poisoned");
                         let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
                         for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
@@ -85,7 +98,7 @@ impl Mul for &Tensor {
                         }
                     }
                     if b.requires_grad {
-                        let adat = a.data();
+                        let adat = a.elements();
                         let mut slot = b.grad.write().expect("grad RwLock poisoned");
                         let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
                         for ((g, &go), &av) in gb.iter_mut().zip(gout.iter()).zip(adat.iter()) {
@@ -204,23 +217,31 @@ impl Tensor {
         let n_out = other.shape[1] as i32;
         assert_eq!(k, k2, "Inner dimensions must match: {} vs {}", k, k2);
 
-        let a = self.data();
-        let b = other.data();
+        // A transposed view is already the layout BLAS wants under its trans
+        // flag, so it feeds straight in — no materialization. Anything with a
+        // layout GEMM can't address (a strided sub-window) is packed first.
+        let a = self.packed_operand();
+        let b = other.packed_operand();
+
+        let a_store = a.storage();
+        let b_store = b.storage();
         let mut c = vec![0.0f32; (m * n_out) as usize];
 
         // Forward: C = A * B
         sgemm_rowmajor(
-            no_trans(),
-            no_trans(),
+            trans_flag(&a, false),
+            trans_flag(&b, false),
             m,
             n_out,
             k,
             1.0,
-            &a[..],
-            &b[..],
+            &a_store[a.offset..],
+            &b_store[b.offset..],
             0.0,
             &mut c,
         );
+        drop(a_store);
+        drop(b_store);
 
         let mut out = Tensor::new(c, &[m as usize, n_out as usize]);
 
@@ -242,21 +263,21 @@ impl Tensor {
                         let k = a_shape[1] as i32;
                         let n_out = b_shape[1] as i32;
 
-                        let bdat = b_t.data();
-                        let mut slot = a_t.grad.write().unwrap();
-                        if slot.is_none() {
-                            *slot = Some(vec![0.0; (m * k) as usize]);
-                        }
-                        let ga = slot.as_mut().unwrap();
+                        // Gradients are always dense row-major, so only the
+                        // operand read out of the graph needs a layout flag.
+                        let b_op = b_t.packed_operand();
+                        let b_store = b_op.storage();
+                        let mut slot = a_t.grad.write().expect("grad RwLock poisoned");
+                        let ga = slot.get_or_insert_with(|| vec![0.0; (m * k) as usize]);
                         sgemm_rowmajor(
                             no_trans(),
-                            trans(),
+                            trans_flag(&b_op, true),
                             m,
                             k,
                             n_out,
                             1.0,
                             gout,
-                            &bdat[..],
+                            &b_store[b_op.offset..],
                             1.0,
                             ga,
                         );
@@ -268,20 +289,18 @@ impl Tensor {
                         let n_out = b_shape[1] as i32;
                         let m = a_shape[0] as i32;
 
-                        let adat = a_t.data();
-                        let mut slot = b_t.grad.write().unwrap();
-                        if slot.is_none() {
-                            *slot = Some(vec![0.0; (kdim * n_out) as usize]);
-                        }
-                        let gb = slot.as_mut().unwrap();
+                        let a_op = a_t.packed_operand();
+                        let a_store = a_op.storage();
+                        let mut slot = b_t.grad.write().expect("grad RwLock poisoned");
+                        let gb = slot.get_or_insert_with(|| vec![0.0; (kdim * n_out) as usize]);
                         sgemm_rowmajor(
-                            trans(),
+                            trans_flag(&a_op, true),
                             no_trans(),
                             kdim,
                             n_out,
                             m,
                             1.0,
-                            &adat[..],
+                            &a_store[a_op.offset..],
                             gout,
                             1.0,
                             gb,
@@ -307,7 +326,7 @@ impl Tensor {
 
     /// SIMD-optimized ReLU activation
     pub fn relu(&self) -> Tensor {
-        let data = self.data();
+        let data = self.elements();
         let mut result = vec![0.0; data.len()];
 
         // SIMD ReLU using max with zero
@@ -376,8 +395,8 @@ impl Sub for &Tensor {
     fn sub(self, other: &Tensor) -> Tensor {
         assert_same_shape(self, other, "sub");
 
-        let self_data = self.data();
-        let other_data = other.data();
+        let self_data = self.elements();
+        let other_data = other.elements();
         let mut out_data = vec![0.0; self_data.len()];
 
         // Subtract using SIMD - we can reuse add with negation
@@ -435,8 +454,8 @@ impl Div for &Tensor {
     fn div(self, other: &Tensor) -> Tensor {
         assert_same_shape(self, other, "div");
 
-        let self_data = self.data();
-        let other_data = other.data();
+        let self_data = self.elements();
+        let other_data = other.elements();
         let mut out_data = vec![0.0; self_data.len()];
 
         // Element-wise division
@@ -456,7 +475,7 @@ impl Div for &Tensor {
                 if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
                     // d/da (a/b) = 1/b, d/db (a/b) = -a/b²
                     if a.requires_grad {
-                        let bdat = b.data();
+                        let bdat = b.elements();
                         let mut slot = a.grad.write().expect("grad RwLock poisoned");
                         let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
                         for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
@@ -464,8 +483,8 @@ impl Div for &Tensor {
                         }
                     }
                     if b.requires_grad {
-                        let adat = a.data();
-                        let bdat = b.data();
+                        let adat = a.elements();
+                        let bdat = b.elements();
                         let mut slot = b.grad.write().expect("grad RwLock poisoned");
                         let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
                         for (((g, &go), &av), &bv) in gb

--- a/src/optim.rs
+++ b/src/optim.rs
@@ -119,9 +119,9 @@ impl Adam {
         let weight_decay = weight_decay.unwrap_or(0.0);
 
         // Initialize moment buffers
-        let m: Vec<Vec<f32>> = params.iter().map(|p| vec![0.0; p.data().len()]).collect();
+        let m: Vec<Vec<f32>> = params.iter().map(|p| vec![0.0; p.numel()]).collect();
 
-        let v: Vec<Vec<f32>> = params.iter().map(|p| vec![0.0; p.data().len()]).collect();
+        let v: Vec<Vec<f32>> = params.iter().map(|p| vec![0.0; p.numel()]).collect();
 
         Adam {
             params,

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -265,12 +265,56 @@ pub mod simd {
 
 #[derive(Clone)]
 pub struct Tensor {
+    /// Flat backing buffer. Several tensors may share one storage: a view is a
+    /// different (shape, stride, offset) window onto the same allocation.
     // Use RwLock for read-heavy workloads (most operations read data)
     data: Arc<RwLock<Vec<f32>>>,
     pub(crate) shape: SmallVec<[usize; 4]>,
+    /// Elements to skip in `data` per step along each dimension.
+    pub(crate) stride: SmallVec<[usize; 4]>,
+    /// Index in `data` of this tensor's first logical element.
+    pub(crate) offset: usize,
     pub grad: Arc<RwLock<Option<Vec<f32>>>>,
     pub requires_grad: bool,
     pub tape_node: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+/// A tensor's logical elements as a flat slice.
+///
+/// Borrows the backing storage when the tensor is dense (the overwhelmingly
+/// common case, and free), and materializes only for a genuine view.
+pub enum Elements<'a> {
+    Borrowed(RwLockReadGuard<'a, Vec<f32>>),
+    Owned(Vec<f32>),
+}
+
+impl std::ops::Deref for Elements<'_> {
+    type Target = [f32];
+    #[inline]
+    fn deref(&self) -> &[f32] {
+        match self {
+            Elements::Borrowed(guard) => guard,
+            Elements::Owned(v) => v,
+        }
+    }
+}
+
+/// How a 2D tensor's memory maps onto a GEMM operand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GemmLayout {
+    /// Dense row-major: element `(i, j)` at `i * cols + j`.
+    RowMajor,
+    /// Dense column-major, i.e. a transposed view of a row-major matrix.
+    Transposed,
+}
+
+/// Row-major strides for a densely packed tensor of this shape.
+pub(crate) fn contiguous_strides(shape: &[usize]) -> SmallVec<[usize; 4]> {
+    let mut strides: SmallVec<[usize; 4]> = smallvec::smallvec![1; shape.len()];
+    for i in (0..shape.len().saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    strides
 }
 
 /// Quantized tensor that can hold different precision types
@@ -575,6 +619,8 @@ impl Tensor {
         );
         Tensor {
             data: Arc::new(RwLock::new(data)),
+            stride: contiguous_strides(shape),
+            offset: 0,
             shape: shape.iter().cloned().collect(),
             grad: Arc::new(RwLock::new(None)),
             requires_grad: false,
@@ -585,6 +631,222 @@ impl Tensor {
     /// Total number of elements.
     pub fn numel(&self) -> usize {
         self.shape.iter().product()
+    }
+
+    /// Elements to skip in the backing storage per step along each dimension.
+    pub fn stride(&self) -> &[usize] {
+        &self.stride
+    }
+
+    /// Whether the logical elements are densely packed in row-major order.
+    ///
+    /// Note this is about *layout*: a contiguous tensor can still be a window
+    /// into a larger storage (non-zero `offset`), which is why the raw-slice
+    /// accessors additionally require [`Tensor::owns_whole_storage`].
+    pub fn is_contiguous(&self) -> bool {
+        self.stride == contiguous_strides(&self.shape)
+    }
+
+    /// Whether this tensor spans its entire backing buffer, so the raw slice
+    /// from `data()` is exactly its logical elements in order.
+    fn owns_whole_storage(&self) -> bool {
+        self.offset == 0
+            && self.is_contiguous()
+            && self.data.read().expect("data RwLock poisoned").len() == self.numel()
+    }
+
+    /// Build a view: a new tensor sharing this one's storage under a different
+    /// layout. Shares no gradient state — the caller records the backward edge.
+    fn view_with(
+        &self,
+        shape: SmallVec<[usize; 4]>,
+        stride: SmallVec<[usize; 4]>,
+        offset: usize,
+    ) -> Tensor {
+        debug_assert_eq!(shape.len(), stride.len(), "view: rank mismatch");
+        Tensor {
+            data: Arc::clone(&self.data),
+            shape,
+            stride,
+            offset,
+            grad: Arc::new(RwLock::new(None)),
+            requires_grad: false,
+            tape_node: Arc::new(std::sync::atomic::AtomicUsize::new(crate::tape::NO_NODE)),
+        }
+    }
+
+    /// The backing storage without the layout checks `data()` performs.
+    /// Callers must account for `offset` and `stride` themselves.
+    #[inline]
+    pub(crate) fn storage(&self) -> RwLockReadGuard<'_, Vec<f32>> {
+        self.data.read().expect("data RwLock poisoned")
+    }
+
+    /// How a 2D tensor maps onto a GEMM operand, if it maps at all.
+    ///
+    /// Only *dense* layouts qualify: `sgemm_rowmajor` derives the leading
+    /// dimension from the logical shape, so a strided sub-window (whose leading
+    /// dimension exceeds its row length) has to be materialized instead.
+    pub(crate) fn gemm_layout_2d(&self) -> Option<GemmLayout> {
+        if self.shape.len() != 2 {
+            return None;
+        }
+        let (rows, cols) = (self.shape[0], self.shape[1]);
+        if self.stride[0] == cols && self.stride[1] == 1 {
+            Some(GemmLayout::RowMajor)
+        } else if self.stride[0] == 1 && self.stride[1] == rows {
+            Some(GemmLayout::Transposed)
+        } else {
+            None
+        }
+    }
+
+    /// This tensor's logical elements as a flat slice, valid for any layout.
+    ///
+    /// This is the read path ops should use: `data()` is only correct for dense
+    /// tensors, and `to_vec()` always copies. Prefer this over both.
+    #[inline]
+    pub fn elements(&self) -> Elements<'_> {
+        if self.owns_whole_storage() {
+            Elements::Borrowed(self.data.read().expect("data RwLock poisoned"))
+        } else {
+            Elements::Owned(self.to_vec())
+        }
+    }
+
+    /// A contiguous run of `len` entries along `dim`, as a view.
+    ///
+    /// Every slicing helper reduces to this: taking a window along one axis
+    /// only moves the start offset and shortens that axis's extent, leaving all
+    /// strides untouched.
+    pub fn narrow(&self, dim: usize, start: usize, len: usize) -> Tensor {
+        assert!(
+            dim < self.shape.len(),
+            "narrow: dim {dim} out of range for shape {:?}",
+            self.shape
+        );
+        assert!(
+            start + len <= self.shape[dim],
+            "narrow: [{start}, {}) out of range for dim {dim} of length {}",
+            start + len,
+            self.shape[dim]
+        );
+
+        let mut shape = self.shape.clone();
+        shape[dim] = len;
+        let mut output = self.view_with(
+            shape.clone(),
+            self.stride.clone(),
+            self.offset + start * self.stride[dim],
+        );
+
+        if self.requires_grad {
+            output.requires_grad = true;
+            let input = self.clone();
+            let out = output.clone();
+            let base_shape = self.shape.clone();
+
+            Tape::push_unary_op(self, &output, move || {
+                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                    let base_strides = contiguous_strides(&base_shape);
+                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
+                    let gin = slot.get_or_insert_with(|| vec![0.0; base_shape.iter().product()]);
+
+                    // Walk the window's logical positions, shifting the sliced
+                    // axis back by `start` to land on the base's index.
+                    let ndim = shape.len();
+                    let mut index = vec![0usize; ndim];
+                    for &g in gout.iter() {
+                        let mut base_flat = 0;
+                        for (d, &coord) in index.iter().enumerate() {
+                            let coord = if d == dim { coord + start } else { coord };
+                            base_flat += coord * base_strides[d];
+                        }
+                        gin[base_flat] += g;
+
+                        for d in (0..ndim).rev() {
+                            index[d] += 1;
+                            if index[d] < shape[d] {
+                                break;
+                            }
+                            index[d] = 0;
+                        }
+                    }
+                }
+            });
+        }
+
+        output
+    }
+
+    /// This tensor in a layout GEMM can address, packing only if necessary.
+    ///
+    /// Unlike [`Tensor::contiguous`] this records no backward edge, because the
+    /// caller accumulates gradients into the *original* tensor directly.
+    pub(crate) fn packed_operand(&self) -> Tensor {
+        match self.gemm_layout_2d() {
+            Some(_) => self.clone(),
+            None => Tensor::new(self.to_vec(), &self.shape),
+        }
+    }
+
+    /// This tensor's logical elements in row-major order.
+    ///
+    /// Walks the strides, so it is correct for any view; the contiguous case
+    /// short-circuits to a plain clone.
+    pub fn to_vec(&self) -> Vec<f32> {
+        let storage = self.data.read().expect("data RwLock poisoned");
+        if self.offset == 0 && self.is_contiguous() && storage.len() == self.numel() {
+            return storage.clone();
+        }
+
+        let n = self.numel();
+        let mut out = Vec::with_capacity(n);
+        let ndim = self.shape.len();
+        let mut index = vec![0usize; ndim];
+        let mut cursor = self.offset;
+
+        // Odometer walk: advance the fastest-varying dimension, carrying over.
+        for _ in 0..n {
+            out.push(storage[cursor]);
+            for d in (0..ndim).rev() {
+                index[d] += 1;
+                cursor += self.stride[d];
+                if index[d] < self.shape[d] {
+                    break;
+                }
+                cursor -= self.stride[d] * self.shape[d];
+                index[d] = 0;
+            }
+        }
+        out
+    }
+
+    /// A densely packed tensor with the same logical contents.
+    ///
+    /// Free (shares storage) when already contiguous; otherwise materializes
+    /// and records an identity backward edge, since both sides are indexed in
+    /// the same logical order.
+    pub fn contiguous(&self) -> Tensor {
+        if self.owns_whole_storage() {
+            return self.clone();
+        }
+
+        let mut output = Tensor::new(self.to_vec(), &self.shape);
+
+        if self.requires_grad {
+            output.requires_grad = true;
+            let input = self.clone();
+            let out = output.clone();
+
+            Tape::push_unary_op(self, &output, move || {
+                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                    ops::accumulate_grad(&input, gout);
+                }
+            });
+        }
+
+        output
     }
 
     pub fn scalar(value: f32) -> Self {
@@ -600,13 +862,40 @@ impl Tensor {
         &self.shape
     }
 
+    /// The raw backing slice, valid to index linearly.
+    ///
+    /// # Panics
+    /// If this tensor is a view — a strided or offset window onto a larger
+    /// storage — where linear indexing would silently read the wrong elements.
+    /// Call [`Tensor::to_vec`] for the logical contents of any layout, or
+    /// [`Tensor::contiguous`] to materialize first.
+    ///
+    /// This is a hard assert rather than a `debug_assert` on purpose: reading a
+    /// view as if it were dense produces plausible wrong numbers, which is the
+    /// failure mode this library can least afford.
     #[inline]
     pub fn data(&self) -> RwLockReadGuard<'_, Vec<f32>> {
+        assert!(
+            self.owns_whole_storage(),
+            "data() on a non-contiguous view (shape {:?}, stride {:?}, offset {}); \
+             use to_vec() or contiguous()",
+            self.shape,
+            self.stride,
+            self.offset
+        );
         self.data.read().expect("data RwLock poisoned")
     }
 
+    /// Mutable access to the raw backing slice. Same restriction as [`Tensor::data`].
     #[inline]
     pub fn data_mut(&self) -> RwLockWriteGuard<'_, Vec<f32>> {
+        assert!(
+            self.owns_whole_storage(),
+            "data_mut() on a non-contiguous view (shape {:?}, stride {:?}, offset {})",
+            self.shape,
+            self.stride,
+            self.offset
+        );
         self.data.write().expect("data RwLock poisoned")
     }
 
@@ -638,7 +927,9 @@ impl Tensor {
     }
 
     pub fn backward(&self) {
-        let ones = vec![1.0; self.data().len()];
+        // Gradients are sized by logical element count, which for a view is not
+        // the length of its (shared, possibly larger) backing storage.
+        let ones = vec![1.0; self.numel()];
         *self.grad.write().expect("grad RwLock poisoned") = Some(ones);
 
         // `NO_NODE` (not 0) marks a tensor that is not the output of a recorded
@@ -650,30 +941,22 @@ impl Tensor {
         *self.grad.write().expect("grad RwLock poisoned") = None;
     }
 
-    /// Cache-friendly blocked transpose
+    /// Transpose a 2D tensor. This is a view: it swaps the shape and stride
+    /// metadata and copies nothing.
+    ///
+    /// `Linear::forward` transposes its weight on every call, which previously
+    /// meant a full blocked copy of the weight matrix per forward pass.
     pub fn transpose(&self) -> Tensor {
         assert_eq!(self.shape.len(), 2, "Can only transpose 2D tensors");
 
         let rows = self.shape[0];
         let cols = self.shape[1];
-        let data = self.data().clone(); // Clone once, no more locks
-        let mut result = vec![0.0; data.len()];
-        let block_size = 16; // Optimal for most cache sizes
 
-        for i0 in (0..rows).step_by(block_size) {
-            for j0 in (0..cols).step_by(block_size) {
-                let i_max = (i0 + block_size).min(rows);
-                let j_max = (j0 + block_size).min(cols);
-
-                for i in i0..i_max {
-                    for j in j0..j_max {
-                        result[j * rows + i] = data[i * cols + j];
-                    }
-                }
-            }
-        }
-
-        let mut output = Tensor::new(result, &[cols, rows]);
+        let mut output = self.view_with(
+            smallvec::smallvec![cols, rows],
+            smallvec::smallvec![self.stride[1], self.stride[0]],
+            self.offset,
+        );
 
         if self.requires_grad {
             output.requires_grad = true;
@@ -702,7 +985,7 @@ impl Tensor {
 
     /// SIMD-optimized sigmoid using fast approximation
     pub fn sigmoid(&self) -> Tensor {
-        let data = self.data().clone();
+        let data = self.elements();
         let mut result = vec![0.0; data.len()];
 
         // Fast sigmoid approximation: σ(x) ≈ 0.5 + 0.5 * tanh(0.5 * x)
@@ -955,7 +1238,7 @@ impl Tensor {
     }
 
     pub fn mean(&self) -> Tensor {
-        let data = self.data();
+        let data = self.elements();
         let sum: f32 = data.iter().sum();
         let mean_val = sum / data.len() as f32;
 
@@ -972,7 +1255,7 @@ impl Tensor {
                     let g_each = gout[0] / n;
                     let mut slot = input.grad.write().unwrap();
                     if slot.is_none() {
-                        *slot = Some(vec![0.0; input.data().len()]);
+                        *slot = Some(vec![0.0; input.numel()]);
                     }
                     for gi in slot.as_mut().unwrap().iter_mut() {
                         *gi += g_each;
@@ -984,20 +1267,30 @@ impl Tensor {
         output
     }
 
-    /// Reshape tensor to new shape (must have same total elements)
+    /// Reshape tensor to new shape (must have same total elements).
+    ///
+    /// Free for a contiguous tensor — only the shape and stride metadata
+    /// change. A non-contiguous view has to be packed first, since its logical
+    /// order is not the order its elements sit in memory.
     pub fn reshape(&self, shape: &[usize]) -> Tensor {
         let total_elements: usize = shape.iter().product();
         assert_eq!(
-            self.data().len(),
+            self.numel(),
             total_elements,
             "Cannot reshape tensor of size {} to shape {:?}",
-            self.data().len(),
+            self.numel(),
             shape
         );
 
-        // Reshaping doesn't change data, just the view
-        let data = self.data().clone();
-        let mut output = Tensor::new(data, shape);
+        let mut output = if self.is_contiguous() {
+            self.view_with(
+                shape.iter().copied().collect(),
+                contiguous_strides(shape),
+                self.offset,
+            )
+        } else {
+            Tensor::new(self.to_vec(), shape)
+        };
 
         if self.requires_grad {
             output.requires_grad = true;
@@ -1073,7 +1366,7 @@ impl Tensor {
 
     /// Sum over dimensions
     pub fn sum(&self, dim: Option<usize>, keepdim: bool) -> Tensor {
-        let data = self.data();
+        let data = self.elements();
 
         if let Some(d) = dim {
             assert!(d < self.shape.len(), "Dimension {} out of bounds", d);
@@ -1134,7 +1427,7 @@ impl Tensor {
                     if let Some(gout) = out.grad.read().unwrap().as_ref() {
                         let mut slot = input.grad.write().unwrap();
                         if slot.is_none() {
-                            *slot = Some(vec![0.0; input.data().len()]);
+                            *slot = Some(vec![0.0; input.numel()]);
                         }
                         let gin = slot.as_mut().unwrap();
 
@@ -1199,7 +1492,7 @@ impl Tensor {
 
     /// Max over dimensions, returns (values, indices)
     pub fn max(&self, dim: Option<usize>) -> (Tensor, Tensor) {
-        let data = self.data();
+        let data = self.elements();
 
         if let Some(d) = dim {
             assert!(d < self.shape.len(), "Dimension {} out of bounds", d);
@@ -1320,7 +1613,7 @@ impl Tensor {
                     if let Some(gout) = out.grad.read().unwrap().as_ref() {
                         let mut slot = input.grad.write().unwrap();
                         if slot.is_none() {
-                            *slot = Some(vec![0.0; input.data().len()]);
+                            *slot = Some(vec![0.0; input.numel()]);
                         }
                         let gin = slot.as_mut().unwrap();
                         gin[max_idx] += gout[0];
@@ -1339,7 +1632,7 @@ impl Tensor {
 
     /// Exponential function (SIMD optimized)
     pub fn exp(&self) -> Tensor {
-        let data = self.data().clone();
+        let data = self.elements();
         let mut result = vec![0.0; data.len()];
 
         // SIMD exp using approximation for better performance
@@ -1384,7 +1677,7 @@ impl Tensor {
 
     /// Natural logarithm
     pub fn log(&self) -> Tensor {
-        let data = self.data();
+        let data = self.elements();
         let mut result = vec![0.0; data.len()];
 
         for (i, &x) in data.iter().enumerate() {
@@ -1401,7 +1694,7 @@ impl Tensor {
             Tape::push_unary_op(self, &output, move || {
                 if let Some(gout) = out.grad.read().unwrap().as_ref() {
                     // d/dx ln(x) = 1/x
-                    let x = input.data();
+                    let x = input.elements();
                     let mut slot = input.grad.write().unwrap();
                     if slot.is_none() {
                         *slot = Some(vec![0.0; x.len()]);
@@ -1420,7 +1713,7 @@ impl Tensor {
 
     /// Power function
     pub fn pow(&self, exp: f32) -> Tensor {
-        let data = self.data();
+        let data = self.elements();
         let mut result = vec![0.0; data.len()];
 
         for (i, &x) in data.iter().enumerate() {
@@ -1437,7 +1730,7 @@ impl Tensor {
             Tape::push_unary_op(self, &output, move || {
                 if let Some(gout) = out.grad.read().unwrap().as_ref() {
                     // d/dx x^n = n * x^(n-1)
-                    let x = input.data();
+                    let x = input.elements();
                     let mut slot = input.grad.write().unwrap();
                     if slot.is_none() {
                         *slot = Some(vec![0.0; x.len()]);
@@ -1565,7 +1858,7 @@ impl Tensor {
         let out_spatial = h_out * w_out;
 
         // read-only input slice (hold the guard just to obtain a slice, then drop it)
-        let data_guard = self.data();
+        let data_guard = self.elements();
         let x: &[f32] = &data_guard;
 
         // forward: outputs + argmax (absolute input indices)
@@ -1698,7 +1991,7 @@ impl Tensor {
         let out_spatial = h_out * w_out;
 
         // read-only input slice (drop the lock immediately)
-        let data_guard = self.data();
+        let data_guard = self.elements();
         let x: &[f32] = &data_guard;
 
         let mut output_data = vec![0.0; n * c * out_spatial];
@@ -1844,7 +2137,7 @@ impl Tensor {
         let num_windows = n * spatial;
         let mut col_data = vec![0.0; num_windows * col_size];
 
-        let data = self.data().clone(); // Clone once to avoid lock contention
+        let data = self.elements();
 
         col_data
             .par_chunks_mut(col_size)
@@ -1936,8 +2229,8 @@ impl Tensor {
         assert_eq!(self.shape[1], bias.shape[0]); // C_out
 
         let (n, c, h, w) = (self.shape[0], self.shape[1], self.shape[2], self.shape[3]);
-        let self_data = self.data();
-        let bias_data = bias.data();
+        let self_data = self.elements();
+        let bias_data = bias.elements();
 
         let mut result_data = vec![0.0; self_data.len()];
 
@@ -2011,7 +2304,7 @@ impl Tensor {
             old_shape[axes[3]],
         ];
 
-        let data = self.data();
+        let data = self.elements();
         let mut result_data = vec![0.0; data.len()];
 
         let (d0, d1, d2, d3) = (old_shape[0], old_shape[1], old_shape[2], old_shape[3]);
@@ -2112,7 +2405,7 @@ impl Tensor {
 
     /// Observed finite range of this tensor, widened so it is never degenerate.
     fn finite_range(&self) -> (f32, f32) {
-        let data = self.data();
+        let data = self.elements();
         let mut min_val = f32::INFINITY;
         let mut max_val = f32::NEG_INFINITY;
 
@@ -2150,7 +2443,7 @@ impl Tensor {
         // every value 128 codes too high and clipped half the dynamic range.
         let zero_point = (qmin as f32 - min_val / scale).round() as i32;
 
-        let data = self.data();
+        let data = self.elements();
         let codes = data
             .iter()
             .map(|&x| {
@@ -2208,7 +2501,7 @@ impl Tensor {
     /// Quantize to NF4: normalize by the absolute maximum, then snap each value
     /// to the nearest of the 16 NF4 levels.
     fn quantize_to_nf4(&self) -> NF4Tensor {
-        let data = self.data();
+        let data = self.elements();
         let absmax = data
             .iter()
             .filter(|x| x.is_finite())

--- a/tests/views.rs
+++ b/tests/views.rs
@@ -1,0 +1,217 @@
+//! Strided-view semantics: layout metadata, zero-copy shape ops, and the
+//! guarantee that a view is never silently read as if it were dense.
+
+use taper::{Tape, Tensor};
+
+fn m23() -> Tensor {
+    Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3])
+}
+
+#[test]
+fn a_fresh_tensor_is_contiguous() {
+    let t = m23();
+    assert!(t.is_contiguous());
+    assert_eq!(t.stride(), &[3, 1]);
+    assert_eq!(t.to_vec(), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn transpose_is_a_zero_copy_view() {
+    let t = m23().transpose();
+
+    assert_eq!(t.shape(), &[3, 2]);
+    // Shape and stride are swapped rather than the data being rearranged.
+    assert_eq!(t.stride(), &[1, 3]);
+    assert!(!t.is_contiguous());
+
+    // Logical order still reads out correctly.
+    assert_eq!(t.to_vec(), vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+}
+
+#[test]
+fn transposing_twice_returns_the_original_layout() {
+    let t = m23().transpose().transpose();
+    assert_eq!(t.shape(), &[2, 3]);
+    assert!(t.is_contiguous());
+    assert_eq!(t.to_vec(), m23().to_vec());
+}
+
+/// Reading a view through the raw-slice accessor would return the base
+/// tensor's elements in the wrong order — a plausible-looking wrong answer.
+#[test]
+#[should_panic(expected = "non-contiguous view")]
+fn raw_data_access_on_a_view_is_rejected() {
+    let t = m23().transpose();
+    drop(t.data());
+}
+
+#[test]
+fn contiguous_materializes_a_view_in_logical_order() {
+    let view = m23().transpose();
+    let packed = view.contiguous();
+
+    assert!(packed.is_contiguous());
+    assert_eq!(packed.shape(), &[3, 2]);
+    // Now safe to read as a dense slice.
+    assert_eq!(packed.data().as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+}
+
+#[test]
+fn contiguous_on_an_already_dense_tensor_is_a_no_op() {
+    let t = m23();
+    let c = t.contiguous();
+    assert_eq!(c.to_vec(), t.to_vec());
+    assert!(c.is_contiguous());
+}
+
+/// matmul feeds transposed views straight to GEMM under its trans flag. Each
+/// combination has to agree with the same product computed from dense copies.
+#[test]
+fn matmul_agrees_across_every_operand_layout() {
+    let a = Tensor::new((0..6).map(|i| i as f32 + 1.0).collect(), &[2, 3]);
+    let b = Tensor::new((0..12).map(|i| i as f32 * 0.5 - 2.0).collect(), &[3, 4]);
+
+    let reference = a.matmul(&b).to_vec();
+
+    // Same products, but reached through transposed views of the operands.
+    let a_via_view = a.transpose().transpose();
+    let b_via_view = b.transpose().transpose();
+
+    assert_eq!(a_via_view.matmul(&b).to_vec(), reference);
+    assert_eq!(a.matmul(&b_via_view).to_vec(), reference);
+    assert_eq!(a_via_view.matmul(&b_via_view).to_vec(), reference);
+
+    // A genuinely column-major operand: bᵀ is [4,3], so (bᵀ)ᵀ · nothing —
+    // instead build aᵀ [3,2] and check aᵀᵀ·b once more against the dense path.
+    let a_t = a.transpose(); // [3,2], stride [1,3] — column-major
+    let a_t_dense = a_t.contiguous();
+    assert_eq!(
+        a_t.matmul(&Tensor::new(vec![1.0, 0.0, 0.0, 1.0], &[2, 2]))
+            .to_vec(),
+        a_t_dense
+            .matmul(&Tensor::new(vec![1.0, 0.0, 0.0, 1.0], &[2, 2]))
+            .to_vec()
+    );
+}
+
+#[test]
+fn matmul_through_a_transposed_view_still_backpropagates() {
+    Tape::reset();
+    let w = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]).requires_grad();
+    let x = Tensor::new(vec![1.0, 1.0, 1.0], &[1, 3]);
+
+    // The shape `Linear::forward` uses: x @ wᵀ where wᵀ is a view.
+    let y = x.matmul(&w.transpose().transpose());
+    assert_eq!(y.shape(), &[1, 2]);
+    y.backward();
+
+    let g = w.grad_ref().expect("no gradient through the view");
+    assert_eq!(g.len(), 6);
+    assert!(g.iter().any(|v| *v != 0.0));
+}
+
+/// The gradient of a transposed view must land on the base in base order.
+#[test]
+fn transpose_backward_maps_gradients_back() {
+    Tape::reset();
+    let a = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).requires_grad();
+    let t = a.transpose();
+
+    // Weight each transposed position distinctly so a mis-mapping shows up.
+    let weights = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]);
+    let scaled = &t * &weights;
+    scaled.sum(None, false).backward();
+
+    // grad[i][j] == weights[j][i]
+    let g = a.grad_ref().unwrap();
+    assert_eq!(g.as_slice(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+}
+
+#[test]
+fn elementwise_ops_accept_views() {
+    let a = m23().transpose();
+    let b = m23().transpose();
+    let sum = &a + &b;
+    assert_eq!(sum.shape(), &[3, 2]);
+    assert_eq!(sum.to_vec(), vec![2.0, 8.0, 4.0, 10.0, 6.0, 12.0]);
+}
+
+#[test]
+fn narrow_is_a_view_with_an_offset() {
+    let t = Tensor::new((0..12).map(|i| i as f32).collect(), &[3, 4]);
+    let mid = t.narrow(0, 1, 2);
+
+    assert_eq!(mid.shape(), &[2, 4]);
+    // Strides are untouched; only the start moved.
+    assert_eq!(mid.stride(), &[4, 1]);
+    assert_eq!(mid.to_vec(), vec![4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+}
+
+#[test]
+fn narrow_along_an_inner_axis_is_strided() {
+    let t = Tensor::new((0..12).map(|i| i as f32).collect(), &[3, 4]);
+    let cols = t.narrow(1, 1, 2);
+
+    assert_eq!(cols.shape(), &[3, 2]);
+    assert!(!cols.is_contiguous(), "an inner window must stay strided");
+    assert_eq!(cols.to_vec(), vec![1.0, 2.0, 5.0, 6.0, 9.0, 10.0]);
+}
+
+#[test]
+fn narrow_scatters_gradients_to_the_right_window() {
+    Tape::reset();
+    let t = Tensor::new((0..12).map(|i| i as f32).collect(), &[3, 4]).requires_grad();
+    let cols = t.narrow(1, 1, 2);
+    cols.backward();
+
+    // Only the selected columns receive gradient.
+    let g = t.grad_ref().unwrap();
+    let expected: Vec<f32> = (0..12)
+        .map(|i| if i % 4 == 1 || i % 4 == 2 { 1.0 } else { 0.0 })
+        .collect();
+    assert_eq!(g.as_slice(), expected.as_slice());
+}
+
+#[test]
+fn reshape_of_a_contiguous_tensor_is_a_view() {
+    let t = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]);
+    let r = t.reshape(&[3, 2]);
+
+    assert_eq!(r.shape(), &[3, 2]);
+    assert_eq!(r.stride(), &[2, 1]);
+    assert!(r.is_contiguous());
+    assert_eq!(r.to_vec(), t.to_vec());
+}
+
+/// A view's logical order is not its memory order, so reshaping one has to
+/// pack first — otherwise the result would reinterpret the base's layout.
+#[test]
+fn reshape_of_a_view_packs_first() {
+    let t = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]);
+    let r = t.transpose().reshape(&[2, 3]);
+
+    assert!(r.is_contiguous());
+    // Transposed order is [0,3,1,4,2,5]; reshaping regroups that, not the base.
+    assert_eq!(r.to_vec(), vec![0.0, 3.0, 1.0, 4.0, 2.0, 5.0]);
+}
+
+#[test]
+fn slicing_helpers_produce_views_that_still_backpropagate() {
+    Tape::reset();
+    let w = Tensor::new((0..36).map(|i| i as f32 * 0.1).collect(), &[4, 1, 3, 3]).requires_grad();
+    let half = w.slice_output_channels(2, 4);
+
+    assert_eq!(half.shape(), &[2, 1, 3, 3]);
+    assert_eq!(half.to_vec()[0], w.to_vec()[18]);
+
+    half.backward();
+    let g = w.grad_ref().unwrap();
+    assert!(
+        g[..18].iter().all(|v| *v == 0.0),
+        "unselected filters got gradient"
+    );
+    assert!(
+        g[18..].iter().all(|v| *v == 1.0),
+        "selected filters missed gradient"
+    );
+}


### PR DESCRIPTION
Tensor gains (stride, offset) alongside shape, so shape-only operations edit metadata instead of copying. transpose feeds GEMM directly under its trans flag, which removes the full weight copy Linear::forward did on every pass, and the three slice helpers collapse onto one strided narrow().

MLP epoch 0.26s -> 0.16s, CNN 12k samples 3.2s -> 1.3s, accuracy unchanged.

data() now hard-asserts that the tensor owns its whole storage: reading a view as if it were dense yields plausible wrong numbers, so ops read through elements(), which borrows when dense and materializes only for a real view.