### PR TITLE
Link system OpenBLAS in CI instead of building it from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,24 @@ jobs:
       - name: Doc tests
         run: cargo test --doc
 
+  # The `blas` feature swaps in a whole different gemm implementation, so it
+  # needs its own build. Both vendors are covered because the failure mode is
+  # in linkage, which differs per vendor, not in our code.
   blas:
-    name: openblas backend
-    runs-on: ubuntu-latest
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: blas (accelerate)
+            os: macos-latest
+            feature: blas-accelerate
+            setup: ""
+          - name: blas (openblas)
+            os: ubuntu-latest
+            feature: blas-openblas-system
+            setup: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
     env:
       RUSTFLAGS: "-D warnings"
     steps:
@@ -66,10 +81,11 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          key: openblas
-      - name: Install OpenBLAS
-        run: sudo apt-get update && sudo apt-get install -y libopenblas-dev gfortran
+          key: ${{ matrix.name }}
+      - name: Install BLAS
+        if: matrix.setup != ''
+        run: ${{ matrix.setup }}
       - name: Clippy
-        run: cargo clippy --features blas-openblas --all-targets -- -D warnings
+        run: cargo clippy --features ${{ matrix.feature }} --all-targets -- -D warnings
       - name: Test
-        run: cargo test --features blas-openblas --all-targets
+        run: cargo test --features ${{ matrix.feature }} --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
  "lazy_static",
  "matrixmultiply",
  "mimalloc",
+ "openblas-src",
  "rand",
  "rand_distr",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ indicatif = "0.17"
 matrixmultiply = "0.3"
 cblas-sys = { version = "0.1", optional = true }
 blas-src   = { version = "0.10", default-features = false, optional = true } # vendor chosen by features below
+# Only pulled in by `blas-openblas-system`, to flip openblas-src onto the
+# already-installed library instead of compiling OpenBLAS from source.
+openblas-src = { version = "0.10", default-features = false, features = ["system"], optional = true }
 rayon = { version = "1.10" }
 lazy_static = "1.4"
 
@@ -25,7 +28,11 @@ default = []
 
 # Enable BLAS via CBLAS API and select a vendor:
 blas = ["cblas-sys", "blas-src"]                # turn on CBLAS
-blas-openblas = ["blas", "blas-src/openblas"]   # build & link OpenBLAS
+blas-openblas = ["blas", "blas-src/openblas"]   # build OpenBLAS from source, then link it
+# Link an OpenBLAS already on the system (apt: libopenblas-dev). Building from
+# source needs a Fortran toolchain, takes minutes, and emits a shared object
+# that then has to be found via LD_LIBRARY_PATH.
+blas-openblas-system = ["blas-openblas", "dep:openblas-src"]
 blas-accelerate = ["blas", "blas-src/accelerate"] # macOS Accelerate
 
 [dev-dependencies]


### PR DESCRIPTION
Follow-up to #11, which merged before this second commit landed.

`openblas-src` builds OpenBLAS from source: it needs a Fortran toolchain, takes
minutes, and emits a shared object that then has to be located via
`LD_LIBRARY_PATH`. It failed outright on the runner. CI already apt-installs
`libopenblas-dev`, so a new `blas-openblas-system` feature points `openblas-src`
at that instead.

The BLAS job is now a matrix over both vendors — what differs per vendor is
linkage, not our code, and Accelerate is verified passing locally.