### PR TITLE
Tier 0: broadcasting and a real autograd graph

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -25,37 +25,8 @@ use crate::tensor::simd;
 impl Add for &Tensor {
     type Output = Tensor;
     fn add(self, other: &Tensor) -> Tensor {
-        assert_same_shape(self, other, "add");
-
-        let a_data = self.elements();
-        let b_data = other.elements();
-        let mut out_data = vec![0.0; a_data.len()];
-
-        // Use SIMD operations
-        unsafe {
-            simd::add_f32_simd(&a_data, &b_data, &mut out_data);
-        }
-
-        let mut out = Tensor::new(out_data, &self.shape);
-
-        if self.requires_grad || other.requires_grad {
-            out.requires_grad = true;
-            let a = self.clone();
-            let b = other.clone();
-            let o = out.clone();
-
-            Tape::push_binary_op(self, other, &out, move || {
-                if let Some(gout) = o.grad.read().unwrap().as_ref() {
-                    if a.requires_grad {
-                        accumulate_grad(&a, gout);
-                    }
-                    if b.requires_grad {
-                        accumulate_grad(&b, gout);
-                    }
-                }
-            });
-        }
-        out
+        let (lhs, rhs) = broadcast_pair(self, other, "add");
+        elementwise_add(&lhs, &rhs)
     }
 }
 
@@ -65,50 +36,8 @@ impl Mul for &Tensor {
     // the multiplication itself, which clippy's heuristic cannot distinguish.
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, other: &Tensor) -> Tensor {
-        assert_same_shape(self, other, "mul");
-
-        let self_data = self.elements();
-        let other_data = other.elements();
-        let mut out_data = vec![0.0; self_data.len()];
-
-        // Use SIMD operations
-        unsafe {
-            simd::mul_f32_simd(&self_data, &other_data, &mut out_data);
-        }
-
-        let mut out = Tensor::new(out_data, &self.shape);
-
-        if self.requires_grad || other.requires_grad {
-            out.requires_grad = true;
-            let a = self.clone();
-            let b = other.clone();
-            let o = out.clone();
-
-            Tape::push_binary_op(self, other, &out, move || {
-                if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
-                    // d/da (a*b) = b, d/db (a*b) = a. Each branch used to size the
-                    // gradient from the *other* operand's data and round-trip
-                    // through two scratch buffers; fold it into one pass.
-                    if a.requires_grad {
-                        let bdat = b.elements();
-                        let mut slot = a.grad.write().expect("grad RwLock poisoned");
-                        let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
-                        for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
-                            *g += go * bv;
-                        }
-                    }
-                    if b.requires_grad {
-                        let adat = a.elements();
-                        let mut slot = b.grad.write().expect("grad RwLock poisoned");
-                        let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
-                        for ((g, &go), &av) in gb.iter_mut().zip(gout.iter()).zip(adat.iter()) {
-                            *g += go * av;
-                        }
-                    }
-                }
-            });
-        }
-        out
+        let (lhs, rhs) = broadcast_pair(self, other, "mul");
+        elementwise_mul(&lhs, &rhs)
     }
 }
 
@@ -145,19 +74,29 @@ pub fn accumulate_grad_scaled(t: &Tensor, src: &[f32], scale: f32) {
     }
 }
 
-/// Shared precondition for the element-wise operators: identical shapes.
+/// Bring two element-wise operands to a common shape under NumPy rules.
 ///
-/// Checking only the flat length let `[2,3] + [3,2]` through and silently
-/// produced a result labelled with the left operand's shape.
+/// Returns the operands already stretched, so the caller works with matching
+/// extents. Equal shapes short-circuit to plain clones, keeping the common case
+/// free; anything else becomes a stride-0 view, and `expand`'s backward sums
+/// the gradient back over the stretched axes.
+///
+/// Previously the operators demanded identical shapes and broadcasting existed
+/// only as three hand-written special cases (`add_broadcast`,
+/// `sub_broadcast_rows`, `div_broadcast_rows`).
 #[inline]
-fn assert_same_shape(a: &Tensor, b: &Tensor, op: &str) {
-    assert_eq!(
-        a.shape(),
-        b.shape(),
-        "{op}: tensor shapes must match ({:?} vs {:?})",
-        a.shape(),
-        b.shape()
-    );
+fn broadcast_pair(a: &Tensor, b: &Tensor, op: &str) -> (Tensor, Tensor) {
+    if a.shape() == b.shape() {
+        return (a.clone(), b.clone());
+    }
+    let target = crate::tensor::broadcast_shape(a.shape(), b.shape()).unwrap_or_else(|| {
+        panic!(
+            "{op}: shapes {:?} and {:?} do not broadcast",
+            a.shape(),
+            b.shape()
+        )
+    });
+    (a.expand(&target), b.expand(&target))
 }
 
 // Implement other trait combinations
@@ -393,37 +332,8 @@ impl Tensor {
 impl Sub for &Tensor {
     type Output = Tensor;
     fn sub(self, other: &Tensor) -> Tensor {
-        assert_same_shape(self, other, "sub");
-
-        let self_data = self.elements();
-        let other_data = other.elements();
-        let mut out_data = vec![0.0; self_data.len()];
-
-        // Subtract using SIMD - we can reuse add with negation
-        for i in 0..out_data.len() {
-            out_data[i] = self_data[i] - other_data[i];
-        }
-
-        let mut out = Tensor::new(out_data, &self.shape);
-
-        if self.requires_grad || other.requires_grad {
-            out.requires_grad = true;
-            let a = self.clone();
-            let b = other.clone();
-            let o = out.clone();
-
-            Tape::push_binary_op(self, other, &out, move || {
-                if let Some(gout) = o.grad.read().unwrap().as_ref() {
-                    if a.requires_grad {
-                        accumulate_grad(&a, gout);
-                    }
-                    if b.requires_grad {
-                        accumulate_grad_scaled(&b, gout, -1.0);
-                    }
-                }
-            });
-        }
-        out
+        let (lhs, rhs) = broadcast_pair(self, other, "sub");
+        elementwise_sub(&lhs, &rhs)
     }
 }
 
@@ -452,54 +362,8 @@ impl Sub for Tensor {
 impl Div for &Tensor {
     type Output = Tensor;
     fn div(self, other: &Tensor) -> Tensor {
-        assert_same_shape(self, other, "div");
-
-        let self_data = self.elements();
-        let other_data = other.elements();
-        let mut out_data = vec![0.0; self_data.len()];
-
-        // Element-wise division
-        for i in 0..out_data.len() {
-            out_data[i] = self_data[i] / other_data[i];
-        }
-
-        let mut out = Tensor::new(out_data, &self.shape);
-
-        if self.requires_grad || other.requires_grad {
-            out.requires_grad = true;
-            let a = self.clone();
-            let b = other.clone();
-            let o = out.clone();
-
-            Tape::push_binary_op(self, other, &out, move || {
-                if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
-                    // d/da (a/b) = 1/b, d/db (a/b) = -a/b²
-                    if a.requires_grad {
-                        let bdat = b.elements();
-                        let mut slot = a.grad.write().expect("grad RwLock poisoned");
-                        let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
-                        for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
-                            *g += go / bv;
-                        }
-                    }
-                    if b.requires_grad {
-                        let adat = a.elements();
-                        let bdat = b.elements();
-                        let mut slot = b.grad.write().expect("grad RwLock poisoned");
-                        let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
-                        for (((g, &go), &av), &bv) in gb
-                            .iter_mut()
-                            .zip(gout.iter())
-                            .zip(adat.iter())
-                            .zip(bdat.iter())
-                        {
-                            *g -= go * av / (bv * bv);
-                        }
-                    }
-                }
-            });
-        }
-        out
+        let (lhs, rhs) = broadcast_pair(self, other, "div");
+        elementwise_div(&lhs, &rhs)
     }
 }
 
@@ -523,4 +387,166 @@ impl Div for Tensor {
     fn div(self, other: Tensor) -> Tensor {
         (&self).div(&other)
     }
+}
+
+/// Element-wise `add` on operands already brought to a common shape.
+fn elementwise_add(this: &Tensor, other: &Tensor) -> Tensor {
+    let a_data = this.elements();
+    let b_data = other.elements();
+    let mut out_data = vec![0.0; a_data.len()];
+
+    // Use SIMD operations
+    unsafe {
+        simd::add_f32_simd(&a_data, &b_data, &mut out_data);
+    }
+
+    let mut out = Tensor::new(out_data, &this.shape);
+
+    if this.requires_grad || other.requires_grad {
+        out.requires_grad = true;
+        let a = this.clone();
+        let b = other.clone();
+        let o = out.clone();
+
+        Tape::push_binary_op(this, other, &out, move || {
+            if let Some(gout) = o.grad.read().unwrap().as_ref() {
+                if a.requires_grad {
+                    accumulate_grad(&a, gout);
+                }
+                if b.requires_grad {
+                    accumulate_grad(&b, gout);
+                }
+            }
+        });
+    }
+    out
+}
+
+/// Element-wise `mul` on operands already brought to a common shape.
+fn elementwise_mul(this: &Tensor, other: &Tensor) -> Tensor {
+    let self_data = this.elements();
+    let other_data = other.elements();
+    let mut out_data = vec![0.0; self_data.len()];
+
+    // Use SIMD operations
+    unsafe {
+        simd::mul_f32_simd(&self_data, &other_data, &mut out_data);
+    }
+
+    let mut out = Tensor::new(out_data, &this.shape);
+
+    if this.requires_grad || other.requires_grad {
+        out.requires_grad = true;
+        let a = this.clone();
+        let b = other.clone();
+        let o = out.clone();
+
+        Tape::push_binary_op(this, other, &out, move || {
+            if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
+                // d/da (a*b) = b, d/db (a*b) = a. Each branch used to size the
+                // gradient from the *other* operand's data and round-trip
+                // through two scratch buffers; fold it into one pass.
+                if a.requires_grad {
+                    let bdat = b.elements();
+                    let mut slot = a.grad.write().expect("grad RwLock poisoned");
+                    let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
+                    for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
+                        *g += go * bv;
+                    }
+                }
+                if b.requires_grad {
+                    let adat = a.elements();
+                    let mut slot = b.grad.write().expect("grad RwLock poisoned");
+                    let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
+                    for ((g, &go), &av) in gb.iter_mut().zip(gout.iter()).zip(adat.iter()) {
+                        *g += go * av;
+                    }
+                }
+            }
+        });
+    }
+    out
+}
+
+/// Element-wise `sub` on operands already brought to a common shape.
+fn elementwise_sub(this: &Tensor, other: &Tensor) -> Tensor {
+    let self_data = this.elements();
+    let other_data = other.elements();
+    let mut out_data = vec![0.0; self_data.len()];
+
+    // Subtract using SIMD - we can reuse add with negation
+    for i in 0..out_data.len() {
+        out_data[i] = self_data[i] - other_data[i];
+    }
+
+    let mut out = Tensor::new(out_data, &this.shape);
+
+    if this.requires_grad || other.requires_grad {
+        out.requires_grad = true;
+        let a = this.clone();
+        let b = other.clone();
+        let o = out.clone();
+
+        Tape::push_binary_op(this, other, &out, move || {
+            if let Some(gout) = o.grad.read().unwrap().as_ref() {
+                if a.requires_grad {
+                    accumulate_grad(&a, gout);
+                }
+                if b.requires_grad {
+                    accumulate_grad_scaled(&b, gout, -1.0);
+                }
+            }
+        });
+    }
+    out
+}
+
+/// Element-wise `div` on operands already brought to a common shape.
+fn elementwise_div(this: &Tensor, other: &Tensor) -> Tensor {
+    let self_data = this.elements();
+    let other_data = other.elements();
+    let mut out_data = vec![0.0; self_data.len()];
+
+    // Element-wise division
+    for i in 0..out_data.len() {
+        out_data[i] = self_data[i] / other_data[i];
+    }
+
+    let mut out = Tensor::new(out_data, &this.shape);
+
+    if this.requires_grad || other.requires_grad {
+        out.requires_grad = true;
+        let a = this.clone();
+        let b = other.clone();
+        let o = out.clone();
+
+        Tape::push_binary_op(this, other, &out, move || {
+            if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
+                // d/da (a/b) = 1/b, d/db (a/b) = -a/b²
+                if a.requires_grad {
+                    let bdat = b.elements();
+                    let mut slot = a.grad.write().expect("grad RwLock poisoned");
+                    let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
+                    for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
+                        *g += go / bv;
+                    }
+                }
+                if b.requires_grad {
+                    let adat = a.elements();
+                    let bdat = b.elements();
+                    let mut slot = b.grad.write().expect("grad RwLock poisoned");
+                    let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
+                    for (((g, &go), &av), &bv) in gb
+                        .iter_mut()
+                        .zip(gout.iter())
+                        .zip(adat.iter())
+                        .zip(bdat.iter())
+                    {
+                        *g -= go * av / (bv * bv);
+                    }
+                }
+            }
+        });
+    }
+    out
 }

--- a/src/tape.rs
+++ b/src/tape.rs
@@ -1,5 +1,8 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::atomic::Ordering;
+
+use smallvec::SmallVec;
 
 use crate::tensor::Tensor;
 
@@ -11,7 +14,7 @@ thread_local! {
     /// The tape never escapes its thread, so `Rc<RefCell<_>>` is the honest
     /// representation; the previous `Arc<RwLock<_>>` paid for atomic refcounts
     /// and lock arbitration that could never be contended.
-    static TAPE: RefCell<Vec<Rc<dyn Fn()>>> = const { RefCell::new(Vec::new()) };
+    static TAPE: RefCell<Vec<Node>> = const { RefCell::new(Vec::new()) };
 
     /// Whether operations should record backward closures on the tape.
     static GRAD_ENABLED: Cell<bool> = const { Cell::new(true) };
@@ -22,6 +25,15 @@ thread_local! {
 /// The tape is per-thread: a graph built on one thread can only be
 /// differentiated on that same thread.
 pub struct Tape;
+
+/// One recorded operation: how to propagate its gradient, and which earlier
+/// operations produced its inputs.
+struct Node {
+    backward_fn: Rc<dyn Fn()>,
+    /// Tape ids of the operands' producing operations. Inputs that are graph
+    /// leaves (parameters, constants) have no producer and are omitted.
+    parents: SmallVec<[usize; 2]>,
+}
 
 /// RAII guard that disables gradient recording for its lifetime.
 ///
@@ -79,7 +91,7 @@ impl Tape {
         if !(a.requires_grad || b.requires_grad) {
             return;
         }
-        Self::push(output, backward_fn);
+        Self::push(&[a, b], output, backward_fn);
     }
 
     pub fn push_unary_op<F>(input: &Tensor, output: &Tensor, backward_fn: F)
@@ -89,10 +101,10 @@ impl Tape {
         if !input.requires_grad {
             return;
         }
-        Self::push(output, backward_fn);
+        Self::push(&[input], output, backward_fn);
     }
 
-    fn push<F>(output: &Tensor, backward_fn: F)
+    fn push<F>(inputs: &[&Tensor], output: &Tensor, backward_fn: F)
     where
         F: Fn() + 'static,
     {
@@ -100,19 +112,30 @@ impl Tape {
             return;
         }
 
+        let parents: SmallVec<[usize; 2]> = inputs
+            .iter()
+            .map(|t| t.tape_node.load(Ordering::SeqCst))
+            .filter(|&id| id != NO_NODE)
+            .collect();
+
         let id = TAPE.with(|tape| {
             let mut nodes = tape.borrow_mut();
-            nodes.push(Rc::new(backward_fn));
+            nodes.push(Node {
+                backward_fn: Rc::new(backward_fn),
+                parents,
+            });
             nodes.len() - 1
         });
-        output
-            .tape_node
-            .store(id, std::sync::atomic::Ordering::SeqCst);
+        output.tape_node.store(id, Ordering::SeqCst);
     }
 }
 
-/// Execute backward functions up to `final_node_id` (inclusive), in reverse.
-/// We clone closures out first to avoid holding any borrows while executing.
+/// Propagate gradients backwards from the operation that produced a tensor.
+///
+/// Only operations `final_node_id` actually depends on are run. The tape used
+/// to replay *every* node up to that id, which did wasted work in the common
+/// case and was outright wrong with two independent graphs on one tape:
+/// differentiating one would also run the other's backward passes.
 pub fn backward(final_node_id: usize) {
     if final_node_id == NO_NODE {
         return;
@@ -126,11 +149,33 @@ pub fn backward(final_node_id: usize) {
             return Vec::new();
         }
         let end = final_node_id.min(nodes.len() - 1);
-        nodes[..=end].to_vec()
+
+        // Reachability over the parent edges.
+        let mut needed = vec![false; end + 1];
+        needed[end] = true;
+        let mut stack = vec![end];
+        while let Some(id) = stack.pop() {
+            for &parent in &nodes[id].parents {
+                if parent <= end && !needed[parent] {
+                    needed[parent] = true;
+                    stack.push(parent);
+                }
+            }
+        }
+
+        // Ids are handed out in creation order and every operand predates the
+        // operation consuming it, so descending id order is already a valid
+        // reverse-topological order — no sort required. Collected in execution
+        // order, so the caller must not reverse it again.
+        (0..=end)
+            .rev()
+            .filter(|&i| needed[i])
+            .map(|i| nodes[i].backward_fn.clone())
+            .collect()
     });
 
-    // Run in reverse with no outstanding borrows.
-    for f in fns.into_iter().rev() {
+    // Already in execution order; run with no outstanding borrows.
+    for f in fns {
         (f)();
     }
 }

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -308,6 +308,38 @@ pub enum GemmLayout {
     Transposed,
 }
 
+/// The shape two operands broadcast to under NumPy rules, or `None` if they
+/// are incompatible.
+///
+/// Shapes are right-aligned; along each axis the extents must match, or one of
+/// them must be 1 (which is then stretched).
+pub fn broadcast_shape(a: &[usize], b: &[usize]) -> Option<SmallVec<[usize; 4]>> {
+    let rank = a.len().max(b.len());
+    let mut out: SmallVec<[usize; 4]> = smallvec::smallvec![0; rank];
+
+    for i in 0..rank {
+        // Missing leading axes behave as extent 1.
+        let da = if i + a.len() >= rank {
+            a[i + a.len() - rank]
+        } else {
+            1
+        };
+        let db = if i + b.len() >= rank {
+            b[i + b.len() - rank]
+        } else {
+            1
+        };
+
+        out[i] = match (da, db) {
+            (x, y) if x == y => x,
+            (1, y) => y,
+            (x, 1) => x,
+            _ => return None,
+        };
+    }
+    Some(out)
+}
+
 /// Row-major strides for a densely packed tensor of this shape.
 pub(crate) fn contiguous_strides(shape: &[usize]) -> SmallVec<[usize; 4]> {
     let mut strides: SmallVec<[usize; 4]> = smallvec::smallvec![1; shape.len()];
@@ -712,6 +744,88 @@ impl Tensor {
         } else {
             Elements::Owned(self.to_vec())
         }
+    }
+
+    /// Stretch this tensor to `target` under NumPy broadcasting rules.
+    ///
+    /// This copies nothing: a stretched axis gets **stride 0**, so every index
+    /// along it reads the same element. Backward sums the gradient back over
+    /// the stretched axes, which is what makes a broadcast bias accumulate
+    /// contributions from the whole batch.
+    pub fn expand(&self, target: &[usize]) -> Tensor {
+        if self.shape.as_slice() == target {
+            return self.clone();
+        }
+        assert!(
+            target.len() >= self.shape.len(),
+            "expand: cannot reduce rank {:?} -> {target:?}",
+            self.shape
+        );
+
+        let lead = target.len() - self.shape.len();
+        let mut stride: SmallVec<[usize; 4]> = smallvec::smallvec![0; target.len()];
+
+        for (i, &want) in target.iter().enumerate() {
+            if i < lead {
+                // A new leading axis: repeat the whole tensor along it.
+                stride[i] = 0;
+                continue;
+            }
+            let have = self.shape[i - lead];
+            if have == want {
+                stride[i] = self.stride[i - lead];
+            } else if have == 1 {
+                stride[i] = 0;
+            } else {
+                panic!(
+                    "expand: cannot stretch axis {i} from {have} to {want} ({:?} -> {target:?})",
+                    self.shape
+                );
+            }
+        }
+
+        let mut output = self.view_with(target.iter().copied().collect(), stride, self.offset);
+
+        if self.requires_grad {
+            output.requires_grad = true;
+            let input = self.clone();
+            let out = output.clone();
+            let src_shape = self.shape.clone();
+            let target: SmallVec<[usize; 4]> = target.iter().copied().collect();
+
+            Tape::push_unary_op(self, &output, move || {
+                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                    let src_strides = contiguous_strides(&src_shape);
+                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
+                    let gin = slot.get_or_insert_with(|| vec![0.0; src_shape.iter().product()]);
+
+                    // Every expanded position folds back onto the source
+                    // element it was reading, so stretched axes sum.
+                    let rank = target.len();
+                    let mut index = vec![0usize; rank];
+                    for &g in gout.iter() {
+                        let mut flat = 0;
+                        for (d, &coord) in index.iter().enumerate().skip(lead) {
+                            let s = d - lead;
+                            if src_shape[s] != 1 {
+                                flat += coord * src_strides[s];
+                            }
+                        }
+                        gin[flat] += g;
+
+                        for d in (0..rank).rev() {
+                            index[d] += 1;
+                            if index[d] < target[d] {
+                                break;
+                            }
+                            index[d] = 0;
+                        }
+                    }
+                }
+            });
+        }
+
+        output
     }
 
     /// A contiguous run of `len` entries along `dim`, as a view.

--- a/tests/broadcasting.rs
+++ b/tests/broadcasting.rs
@@ -1,0 +1,148 @@
+//! NumPy-rule broadcasting, implemented as stride-0 views.
+
+use taper::tensor::broadcast_shape;
+use taper::{Tape, Tensor};
+
+#[test]
+fn shape_rules_match_numpy() {
+    let cases: &[(&[usize], &[usize], Option<&[usize]>)] = &[
+        (&[3, 4], &[3, 4], Some(&[3, 4])),
+        (&[3, 4], &[4], Some(&[3, 4])), // right-aligned, rank lifted
+        (&[3, 1], &[1, 4], Some(&[3, 4])), // both stretch
+        (&[5, 1, 4], &[3, 1], Some(&[5, 3, 4])), // mixed rank
+        (&[3, 4], &[1], Some(&[3, 4])), // scalar-ish
+        (&[3, 4], &[3, 2], None),       // incompatible
+        (&[3, 4], &[2, 3, 5], None),
+    ];
+
+    for (a, b, want) in cases {
+        let got = broadcast_shape(a, b);
+        match want {
+            Some(w) => assert_eq!(got.as_deref(), Some(*w), "{a:?} vs {b:?}"),
+            None => assert!(got.is_none(), "{a:?} vs {b:?} should not broadcast"),
+        }
+        // Broadcasting is symmetric.
+        assert_eq!(
+            broadcast_shape(a, b).is_some(),
+            broadcast_shape(b, a).is_some()
+        );
+    }
+}
+
+#[test]
+fn expand_is_a_stride_zero_view() {
+    let row = Tensor::new(vec![1.0, 2.0, 3.0], &[1, 3]);
+    let wide = row.expand(&[4, 3]);
+
+    assert_eq!(wide.shape(), &[4, 3]);
+    // The stretched axis reads the same element every step.
+    assert_eq!(wide.stride(), &[0, 1]);
+    assert_eq!(
+        wide.to_vec(),
+        vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]
+    );
+}
+
+#[test]
+fn expand_lifts_rank_from_the_left() {
+    let v = Tensor::new(vec![1.0, 2.0], &[2]);
+    let lifted = v.expand(&[3, 2]);
+    assert_eq!(lifted.stride(), &[0, 1]);
+    assert_eq!(lifted.to_vec(), vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0]);
+}
+
+#[test]
+fn operators_broadcast_a_row_against_a_matrix() {
+    let m = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]);
+    let row = Tensor::new(vec![10.0, 20.0, 30.0], &[3]);
+
+    let sum = &m + &row;
+    assert_eq!(sum.shape(), &[2, 3]);
+    assert_eq!(sum.to_vec(), vec![10.0, 21.0, 32.0, 13.0, 24.0, 35.0]);
+}
+
+#[test]
+fn operators_broadcast_a_column_against_a_matrix() {
+    let m = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]);
+    let col = Tensor::new(vec![10.0, 20.0], &[2, 1]);
+
+    let sum = &m + &col;
+    assert_eq!(sum.to_vec(), vec![10.0, 11.0, 12.0, 23.0, 24.0, 25.0]);
+}
+
+#[test]
+fn operators_broadcast_both_operands_at_once() {
+    let col = Tensor::new(vec![1.0, 2.0, 3.0], &[3, 1]);
+    let row = Tensor::new(vec![10.0, 20.0], &[1, 2]);
+
+    let outer = &col * &row;
+    assert_eq!(outer.shape(), &[3, 2]);
+    assert_eq!(outer.to_vec(), vec![10.0, 20.0, 20.0, 40.0, 30.0, 60.0]);
+}
+
+/// The whole point of stride 0: a value read many times must collect the
+/// gradient from every position that read it.
+#[test]
+fn expand_sums_gradients_over_stretched_axes() {
+    Tape::reset();
+    let row = Tensor::new(vec![1.0, 2.0, 3.0], &[1, 3]).requires_grad();
+    let wide = row.expand(&[4, 3]);
+    wide.backward();
+
+    // Each element was read by 4 rows.
+    assert_eq!(row.grad_ref().unwrap().as_slice(), &[4.0, 4.0, 4.0]);
+}
+
+#[test]
+fn broadcast_add_reduces_gradient_to_the_bias_shape() {
+    Tape::reset();
+    let m = Tensor::new(vec![0.0; 6], &[2, 3]).requires_grad();
+    let bias = Tensor::new(vec![0.0, 0.0, 0.0], &[3]).requires_grad();
+
+    let out = &m + &bias;
+    out.backward();
+
+    // The matrix sees ones; the bias collects one per row.
+    assert_eq!(m.grad_ref().unwrap().as_slice(), &[1.0; 6]);
+    assert_eq!(bias.grad_ref().unwrap().as_slice(), &[2.0, 2.0, 2.0]);
+}
+
+#[test]
+fn broadcast_mul_routes_gradients_through_both_operands() {
+    Tape::reset();
+    let col = Tensor::new(vec![1.0, 2.0], &[2, 1]).requires_grad();
+    let row = Tensor::new(vec![3.0, 4.0, 5.0], &[1, 3]).requires_grad();
+
+    let outer = &col * &row;
+    outer.backward();
+
+    // d/dcol = sum over the row; d/drow = sum over the column.
+    assert_eq!(col.grad_ref().unwrap().as_slice(), &[12.0, 12.0]);
+    assert_eq!(row.grad_ref().unwrap().as_slice(), &[3.0, 3.0, 3.0]);
+}
+
+/// The three hand-written helpers still work, now on the general machinery.
+#[test]
+fn the_original_broadcast_helpers_still_agree() {
+    let m = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]);
+    let bias = Tensor::new(vec![10.0, 20.0, 30.0], &[3]);
+    assert_eq!(m.add_broadcast(&bias).to_vec(), (&m + &bias).to_vec());
+
+    let rows = Tensor::new(vec![1.0, 2.0], &[2, 1]);
+    assert_eq!(
+        m.sub_broadcast_rows(&rows).to_vec(),
+        vec![-1.0, 0.0, 1.0, 1.0, 2.0, 3.0]
+    );
+    assert_eq!(
+        m.div_broadcast_rows(&rows).to_vec(),
+        vec![0.0, 1.0, 2.0, 1.5, 2.0, 2.5]
+    );
+}
+
+#[test]
+#[should_panic(expected = "do not broadcast")]
+fn incompatible_shapes_are_rejected() {
+    let a = Tensor::new(vec![0.0; 6], &[2, 3]);
+    let b = Tensor::new(vec![0.0; 8], &[2, 4]);
+    let _ = &a + &b;
+}

--- a/tests/broadcasting.rs
+++ b/tests/broadcasting.rs
@@ -3,9 +3,12 @@
 use taper::tensor::broadcast_shape;
 use taper::{Tape, Tensor};
 
+/// `(lhs shape, rhs shape, expected broadcast shape or None)`
+type ShapeCase<'a> = (&'a [usize], &'a [usize], Option<&'a [usize]>);
+
 #[test]
 fn shape_rules_match_numpy() {
-    let cases: &[(&[usize], &[usize], Option<&[usize]>)] = &[
+    let cases: &[ShapeCase] = &[
         (&[3, 4], &[3, 4], Some(&[3, 4])),
         (&[3, 4], &[4], Some(&[3, 4])), // right-aligned, rank lifted
         (&[3, 1], &[1, 4], Some(&[3, 4])), // both stretch

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -446,3 +446,48 @@ fn conv2d_gradients_match_finite_differences() {
         "conv2d produced no input gradient"
     );
 }
+
+/// backward() used to replay every node recorded up to the output's id, so two
+/// independent graphs sharing a tape would each run the other's backward pass.
+#[test]
+fn independent_graphs_on_one_tape_do_not_contaminate_each_other() {
+    Tape::reset();
+    let a = Tensor::new(vec![2.0], &[1]).requires_grad();
+    let b = Tensor::new(vec![3.0], &[1]).requires_grad();
+
+    // Two graphs, recorded interleaved onto the same tape.
+    let ga = &a * &a; // depends only on a
+    let gb = &b * &b; // depends only on b
+
+    ga.backward();
+    assert_eq!(a.grad_ref().unwrap().as_slice(), &[4.0], "d(a²)/da = 2a");
+    assert!(
+        b.grad_ref().is_none(),
+        "differentiating a's graph also ran b's backward"
+    );
+
+    gb.backward();
+    assert_eq!(b.grad_ref().unwrap().as_slice(), &[6.0], "d(b²)/db = 2b");
+}
+
+/// Only the ancestors of the output should run. cross_entropy_loss builds a
+/// log_softmax chain it then bypasses, so those nodes are dead weight.
+#[test]
+fn backward_skips_operations_the_output_does_not_depend_on() {
+    Tape::reset();
+    let x = Tensor::new(vec![1.0, 2.0], &[2]).requires_grad();
+
+    let used = &x + &x;
+    // A side branch that nothing downstream consumes.
+    let _unused = (&x * &x).exp().log();
+    let recorded = Tape::len();
+
+    used.backward();
+
+    assert!(
+        recorded > 2,
+        "expected the unused branch to be on the tape, got {recorded} nodes"
+    );
+    // d(2x)/dx = 2 exactly; had the side branch run, it would have added to x.
+    assert_eq!(x.grad_ref().unwrap().as_slice(), &[2.0, 2.0]);
+}

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -279,7 +279,7 @@ fn checkpoints_round_trip() {
 /// Element-wise ops only checked flat length, so `[2,3] op [3,2]` produced a
 /// result mislabelled with the left operand's shape.
 #[test]
-#[should_panic(expected = "shapes must match")]
+#[should_panic(expected = "do not broadcast")]
 fn elementwise_ops_reject_mismatched_shapes() {
     let a = Tensor::new(vec![1.0; 6], &[2, 3]);
     let b = Tensor::new(vec![1.0; 6], &[3, 2]);


### PR DESCRIPTION
Follows the strided-tensor work in #12.

**Broadcasting (Tier 0.2)** — `expand()` stretches an axis by setting its stride
to 0, so a broadcast operand costs no allocation and its backward sums the
gradient back over the stretched axes. The four element-wise operators now
broadcast through it, replacing a rule that demanded identical shapes plus three
hand-written special cases.

**Autograd graph (Tier 0.4)** — each node records its operands' producing nodes,
and `backward` walks that graph from the output instead of replaying every node
up to its id. Two independent graphs on one tape no longer run each other's
backward passes, and dead branches are skipped rather than executed as no-ops.

### Correction to #12's stated speedups

The numbers in e65db73 (MLP 0.26→0.16s, CNN 3.2→1.3s) were measurement
artifacts: before and after were timed minutes apart with the machine under
different load. Re-measured back-to-back against 802df50 via a git worktree:

| | base (802df50) | now |
| --- | --- | --- |
| MLP epoch | 0.27s | 0.25s |
| CNN, 12k samples | 2.0s | 2.0s |

So ~7% on the MLP and nothing measurable on the CNN. The strided representation
earns its place structurally — it is what makes broadcasting, zero-copy views
and future dtype work possible — not as a speedup.