### PR TITLE
Tier 0.3: dtype enum — narrow storage with f32 compute

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -174,8 +174,8 @@ impl Tensor {
             n_out,
             k,
             1.0,
-            &a_store[a.offset..],
-            &b_store[b.offset..],
+            &a_store.as_f32_slice()[a.offset..],
+            &b_store.as_f32_slice()[b.offset..],
             0.0,
             &mut c,
         );
@@ -216,7 +216,7 @@ impl Tensor {
                             n_out,
                             1.0,
                             gout,
-                            &b_store[b_op.offset..],
+                            &b_store.as_f32_slice()[b_op.offset..],
                             1.0,
                             ga,
                         );
@@ -239,7 +239,7 @@ impl Tensor {
                             n_out,
                             m,
                             1.0,
-                            &a_store[a_op.offset..],
+                            &a_store.as_f32_slice()[a_op.offset..],
                             gout,
                             1.0,
                             gb,

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -263,12 +263,154 @@ pub mod simd {
     }
 }
 
+/// The element type a tensor's storage holds.
+///
+/// Computation is always carried out in `f32`; a narrower dtype shrinks what a
+/// tensor *stores*, not the precision it is evaluated at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DType {
+    F32,
+    BF16,
+    F16,
+    I32,
+    U8,
+}
+
+impl DType {
+    /// Bytes per element.
+    pub fn size_of(&self) -> usize {
+        match self {
+            DType::F32 | DType::I32 => 4,
+            DType::BF16 | DType::F16 => 2,
+            DType::U8 => 1,
+        }
+    }
+}
+
+/// A tensor's backing buffer, in one of the supported element types.
+#[derive(Debug)]
+pub enum Storage {
+    F32(Vec<f32>),
+    BF16(Vec<u16>),
+    F16(Vec<u16>),
+    I32(Vec<i32>),
+    U8(Vec<u8>),
+}
+
+impl Storage {
+    pub fn dtype(&self) -> DType {
+        match self {
+            Storage::F32(_) => DType::F32,
+            Storage::BF16(_) => DType::BF16,
+            Storage::F16(_) => DType::F16,
+            Storage::I32(_) => DType::I32,
+            Storage::U8(_) => DType::U8,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Storage::F32(v) => v.len(),
+            Storage::BF16(v) | Storage::F16(v) => v.len(),
+            Storage::I32(v) => v.len(),
+            Storage::U8(v) => v.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The element at `i`, widened to `f32`.
+    #[inline]
+    fn get_f32(&self, i: usize) -> f32 {
+        match self {
+            Storage::F32(v) => v[i],
+            Storage::BF16(v) => Tensor::bf16_to_f32(v[i]),
+            Storage::F16(v) => Tensor::f16_to_f32(v[i]),
+            Storage::I32(v) => v[i] as f32,
+            Storage::U8(v) => v[i] as f32,
+        }
+    }
+
+    /// The whole buffer widened to `f32`.
+    fn to_f32_vec(&self) -> Vec<f32> {
+        match self {
+            Storage::F32(v) => v.clone(),
+            Storage::BF16(v) => v.iter().map(|&x| Tensor::bf16_to_f32(x)).collect(),
+            Storage::F16(v) => v.iter().map(|&x| Tensor::f16_to_f32(x)).collect(),
+            Storage::I32(v) => v.iter().map(|&x| x as f32).collect(),
+            Storage::U8(v) => v.iter().map(|&x| x as f32).collect(),
+        }
+    }
+
+    /// The buffer as an `f32` slice. Only valid for `F32` storage.
+    #[inline]
+    pub(crate) fn as_f32_slice(&self) -> &[f32] {
+        match self {
+            Storage::F32(v) => v,
+            other => panic!("expected f32 storage, found {:?}", other.dtype()),
+        }
+    }
+
+    /// Narrow an `f32` buffer into this dtype.
+    fn from_f32(values: &[f32], dtype: DType) -> Storage {
+        match dtype {
+            DType::F32 => Storage::F32(values.to_vec()),
+            DType::BF16 => Storage::BF16(values.iter().map(|&x| Tensor::f32_to_bf16(x)).collect()),
+            DType::F16 => Storage::F16(values.iter().map(|&x| Tensor::f32_to_f16(x)).collect()),
+            DType::I32 => Storage::I32(values.iter().map(|&x| x as i32).collect()),
+            DType::U8 => Storage::U8(values.iter().map(|&x| x as u8).collect()),
+        }
+    }
+}
+
+/// Read guard over `f32` storage.
+///
+/// Derefs to `Vec<f32>` so the raw-slice call sites keep working unchanged.
+pub struct F32Ref<'a>(RwLockReadGuard<'a, Storage>);
+
+impl std::ops::Deref for F32Ref<'_> {
+    type Target = Vec<f32>;
+    #[inline]
+    fn deref(&self) -> &Vec<f32> {
+        match &*self.0 {
+            Storage::F32(v) => v,
+            other => panic!("expected f32 storage, found {:?}", other.dtype()),
+        }
+    }
+}
+
+/// Write guard over `f32` storage.
+pub struct F32Mut<'a>(RwLockWriteGuard<'a, Storage>);
+
+impl std::ops::Deref for F32Mut<'_> {
+    type Target = Vec<f32>;
+    #[inline]
+    fn deref(&self) -> &Vec<f32> {
+        match &*self.0 {
+            Storage::F32(v) => v,
+            other => panic!("expected f32 storage, found {:?}", other.dtype()),
+        }
+    }
+}
+
+impl std::ops::DerefMut for F32Mut<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Vec<f32> {
+        match &mut *self.0 {
+            Storage::F32(v) => v,
+            other => panic!("expected f32 storage, found {:?}", other.dtype()),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Tensor {
     /// Flat backing buffer. Several tensors may share one storage: a view is a
     /// different (shape, stride, offset) window onto the same allocation.
     // Use RwLock for read-heavy workloads (most operations read data)
-    data: Arc<RwLock<Vec<f32>>>,
+    data: Arc<RwLock<Storage>>,
     pub(crate) shape: SmallVec<[usize; 4]>,
     /// Elements to skip in `data` per step along each dimension.
     pub(crate) stride: SmallVec<[usize; 4]>,
@@ -284,7 +426,7 @@ pub struct Tensor {
 /// Borrows the backing storage when the tensor is dense (the overwhelmingly
 /// common case, and free), and materializes only for a genuine view.
 pub enum Elements<'a> {
-    Borrowed(RwLockReadGuard<'a, Vec<f32>>),
+    Borrowed(F32Ref<'a>),
     Owned(Vec<f32>),
 }
 
@@ -650,7 +792,7 @@ impl Tensor {
             shape
         );
         Tensor {
-            data: Arc::new(RwLock::new(data)),
+            data: Arc::new(RwLock::new(Storage::F32(data))),
             stride: contiguous_strides(shape),
             offset: 0,
             shape: shape.iter().cloned().collect(),
@@ -670,6 +812,65 @@ impl Tensor {
         &self.stride
     }
 
+    /// The element type this tensor stores.
+    pub fn dtype(&self) -> DType {
+        self.data.read().expect("data RwLock poisoned").dtype()
+    }
+
+    /// Build a tensor directly over a typed buffer.
+    pub fn from_storage(storage: Storage, shape: &[usize]) -> Self {
+        let expected: usize = shape.iter().product();
+        assert_eq!(
+            storage.len(),
+            expected,
+            "from_storage: {} values do not fill shape {shape:?}",
+            storage.len()
+        );
+        Tensor {
+            data: Arc::new(RwLock::new(storage)),
+            stride: contiguous_strides(shape),
+            offset: 0,
+            shape: shape.iter().cloned().collect(),
+            grad: Arc::new(RwLock::new(None)),
+            requires_grad: false,
+            tape_node: Arc::new(std::sync::atomic::AtomicUsize::new(crate::tape::NO_NODE)),
+        }
+    }
+
+    /// Re-store this tensor's values in `dtype`.
+    ///
+    /// Narrowing loses precision, but the cast is element-wise with unit
+    /// derivative, so gradients pass straight through — the same
+    /// straight-through treatment mixed-precision training relies on.
+    pub fn to_dtype(&self, dtype: DType) -> Tensor {
+        if self.dtype() == dtype && self.is_contiguous() && self.offset == 0 {
+            return self.clone();
+        }
+
+        let widened = self.to_vec();
+        let mut output = Tensor::from_storage(Storage::from_f32(&widened, dtype), &self.shape);
+
+        if self.requires_grad {
+            output.requires_grad = true;
+            let input = self.clone();
+            let out = output.clone();
+
+            Tape::push_unary_op(self, &output, move || {
+                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                    ops::accumulate_grad(&input, gout);
+                }
+            });
+        }
+
+        output
+    }
+
+    /// Bytes this tensor's storage occupies.
+    pub fn storage_bytes(&self) -> usize {
+        let storage = self.data.read().expect("data RwLock poisoned");
+        storage.len() * storage.dtype().size_of()
+    }
+
     /// Whether the logical elements are densely packed in row-major order.
     ///
     /// Note this is about *layout*: a contiguous tensor can still be a window
@@ -682,9 +883,11 @@ impl Tensor {
     /// Whether this tensor spans its entire backing buffer, so the raw slice
     /// from `data()` is exactly its logical elements in order.
     fn owns_whole_storage(&self) -> bool {
+        let storage = self.data.read().expect("data RwLock poisoned");
         self.offset == 0
             && self.is_contiguous()
-            && self.data.read().expect("data RwLock poisoned").len() == self.numel()
+            && storage.len() == self.numel()
+            && storage.dtype() == DType::F32
     }
 
     /// Build a view: a new tensor sharing this one's storage under a different
@@ -710,7 +913,7 @@ impl Tensor {
     /// The backing storage without the layout checks `data()` performs.
     /// Callers must account for `offset` and `stride` themselves.
     #[inline]
-    pub(crate) fn storage(&self) -> RwLockReadGuard<'_, Vec<f32>> {
+    pub(crate) fn storage(&self) -> RwLockReadGuard<'_, Storage> {
         self.data.read().expect("data RwLock poisoned")
     }
 
@@ -740,7 +943,7 @@ impl Tensor {
     #[inline]
     pub fn elements(&self) -> Elements<'_> {
         if self.owns_whole_storage() {
-            Elements::Borrowed(self.data.read().expect("data RwLock poisoned"))
+            Elements::Borrowed(F32Ref(self.data.read().expect("data RwLock poisoned")))
         } else {
             Elements::Owned(self.to_vec())
         }
@@ -899,8 +1102,9 @@ impl Tensor {
     /// caller accumulates gradients into the *original* tensor directly.
     pub(crate) fn packed_operand(&self) -> Tensor {
         match self.gemm_layout_2d() {
-            Some(_) => self.clone(),
-            None => Tensor::new(self.to_vec(), &self.shape),
+            // GEMM reads the buffer directly, so a narrow dtype must widen first.
+            Some(_) if self.dtype() == DType::F32 => self.clone(),
+            _ => Tensor::new(self.to_vec(), &self.shape),
         }
     }
 
@@ -911,7 +1115,7 @@ impl Tensor {
     pub fn to_vec(&self) -> Vec<f32> {
         let storage = self.data.read().expect("data RwLock poisoned");
         if self.offset == 0 && self.is_contiguous() && storage.len() == self.numel() {
-            return storage.clone();
+            return storage.to_f32_vec();
         }
 
         let n = self.numel();
@@ -922,7 +1126,7 @@ impl Tensor {
 
         // Odometer walk: advance the fastest-varying dimension, carrying over.
         for _ in 0..n {
-            out.push(storage[cursor]);
+            out.push(storage.get_f32(cursor));
             for d in (0..ndim).rev() {
                 index[d] += 1;
                 cursor += self.stride[d];
@@ -976,41 +1180,48 @@ impl Tensor {
         &self.shape
     }
 
-    /// The raw backing slice, valid to index linearly.
-    ///
-    /// # Panics
-    /// If this tensor is a view — a strided or offset window onto a larger
-    /// storage — where linear indexing would silently read the wrong elements.
-    /// Call [`Tensor::to_vec`] for the logical contents of any layout, or
-    /// [`Tensor::contiguous`] to materialize first.
-    ///
-    /// This is a hard assert rather than a `debug_assert` on purpose: reading a
-    /// view as if it were dense produces plausible wrong numbers, which is the
-    /// failure mode this library can least afford.
+    /// Panic with the specific reason `data()`/`data_mut()` cannot hand out a
+    /// raw f32 slice: wrong dtype, or a strided/offset window.
     #[inline]
-    pub fn data(&self) -> RwLockReadGuard<'_, Vec<f32>> {
+    fn assert_dense_f32(&self, accessor: &str) {
+        let dtype = self.dtype();
+        assert!(
+            dtype == DType::F32,
+            "{accessor} needs f32 storage, but this tensor holds {dtype:?}; \
+             use to_vec(), elements(), or to_dtype(DType::F32)"
+        );
         assert!(
             self.owns_whole_storage(),
-            "data() on a non-contiguous view (shape {:?}, stride {:?}, offset {}); \
+            "{accessor} on a non-contiguous view (shape {:?}, stride {:?}, offset {}); \
              use to_vec() or contiguous()",
             self.shape,
             self.stride,
             self.offset
         );
-        self.data.read().expect("data RwLock poisoned")
+    }
+
+    /// The raw backing slice, valid to index linearly.
+    ///
+    /// # Panics
+    /// If this tensor does not hold `f32`, or is a view — a strided or offset
+    /// window onto a larger storage — where linear indexing would silently read
+    /// the wrong elements. Call [`Tensor::to_vec`] or [`Tensor::elements`] for
+    /// the logical contents of any layout and dtype.
+    ///
+    /// These are hard asserts rather than `debug_assert`s on purpose: reading a
+    /// view as if it were dense produces plausible wrong numbers, which is the
+    /// failure mode this library can least afford.
+    #[inline]
+    pub fn data(&self) -> F32Ref<'_> {
+        self.assert_dense_f32("data()");
+        F32Ref(self.data.read().expect("data RwLock poisoned"))
     }
 
     /// Mutable access to the raw backing slice. Same restriction as [`Tensor::data`].
     #[inline]
-    pub fn data_mut(&self) -> RwLockWriteGuard<'_, Vec<f32>> {
-        assert!(
-            self.owns_whole_storage(),
-            "data_mut() on a non-contiguous view (shape {:?}, stride {:?}, offset {})",
-            self.shape,
-            self.stride,
-            self.offset
-        );
-        self.data.write().expect("data RwLock poisoned")
+    pub fn data_mut(&self) -> F32Mut<'_> {
+        self.assert_dense_f32("data_mut()");
+        F32Mut(self.data.write().expect("data RwLock poisoned"))
     }
 
     /// Read-only view of grad vector if it exists.

--- a/tests/dtype.rs
+++ b/tests/dtype.rs
@@ -1,0 +1,119 @@
+//! Narrow storage dtypes. Computation stays in f32; the dtype controls what a
+//! tensor *stores*, not the precision it is evaluated at.
+
+use taper::tensor::{DType, Storage};
+use taper::{Tape, Tensor};
+
+#[test]
+fn tensors_are_f32_by_default() {
+    let t = Tensor::new(vec![1.0, 2.0], &[2]);
+    assert_eq!(t.dtype(), DType::F32);
+    assert_eq!(t.storage_bytes(), 8);
+}
+
+#[test]
+fn narrow_dtypes_shrink_storage() {
+    let values: Vec<f32> = (0..64).map(|i| i as f32 * 0.25).collect();
+    let f32_t = Tensor::new(values, &[64]);
+    assert_eq!(f32_t.storage_bytes(), 256);
+
+    // Half the bytes for the 16-bit types, a quarter for u8.
+    assert_eq!(f32_t.to_dtype(DType::BF16).storage_bytes(), 128);
+    assert_eq!(f32_t.to_dtype(DType::F16).storage_bytes(), 128);
+    assert_eq!(f32_t.to_dtype(DType::I32).storage_bytes(), 256);
+    assert_eq!(f32_t.to_dtype(DType::U8).storage_bytes(), 64);
+}
+
+#[test]
+fn casting_round_trips_within_the_format_precision() {
+    let values = vec![-2.5, -0.125, 0.0, 1.75, 100.0];
+    let t = Tensor::new(values.clone(), &[5]);
+
+    for (dtype, tolerance) in [(DType::BF16, 1.0), (DType::F16, 0.05)] {
+        let back = t.to_dtype(dtype).to_dtype(DType::F32);
+        assert_eq!(back.dtype(), DType::F32);
+        for (got, want) in back.to_vec().iter().zip(values.iter()) {
+            assert!(
+                (got - want).abs() <= tolerance,
+                "{dtype:?}: {want} round-tripped to {got}"
+            );
+        }
+    }
+}
+
+#[test]
+fn integer_storage_holds_exact_values() {
+    // Class labels are the motivating case: they are integers, not floats.
+    let labels = Tensor::from_storage(Storage::I32(vec![0, 3, 9, 7]), &[4]);
+    assert_eq!(labels.dtype(), DType::I32);
+    assert_eq!(labels.to_vec(), vec![0.0, 3.0, 9.0, 7.0]);
+}
+
+#[test]
+fn u8_storage_holds_exact_values() {
+    let mask = Tensor::from_storage(Storage::U8(vec![0, 1, 1, 0]), &[2, 2]);
+    assert_eq!(mask.dtype(), DType::U8);
+    assert_eq!(mask.to_vec(), vec![0.0, 1.0, 1.0, 0.0]);
+    assert_eq!(mask.storage_bytes(), 4);
+}
+
+/// Ops read through `elements()`, which widens whatever the storage holds, so a
+/// narrow tensor participates in arithmetic without any special casing.
+#[test]
+fn arithmetic_works_across_dtypes() {
+    let a = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], &[4]).to_dtype(DType::BF16);
+    let b = Tensor::from_storage(Storage::I32(vec![10, 20, 30, 40]), &[4]);
+
+    let sum = &a + &b;
+    // The result is computed and stored in f32.
+    assert_eq!(sum.dtype(), DType::F32);
+    assert_eq!(sum.to_vec(), vec![11.0, 22.0, 33.0, 44.0]);
+}
+
+#[test]
+fn matmul_accepts_narrow_operands() {
+    let a = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    let b = Tensor::new(vec![1.0, 0.0, 0.0, 1.0], &[2, 2]);
+    let reference = a.matmul(&b).to_vec();
+
+    // bf16 holds these exactly, so the product must be identical.
+    let narrow = a.to_dtype(DType::BF16);
+    assert_eq!(narrow.matmul(&b).to_vec(), reference);
+    assert_eq!(a.matmul(&b.to_dtype(DType::BF16)).to_vec(), reference);
+}
+
+/// The cast is element-wise with unit derivative, so gradients pass through.
+#[test]
+fn casting_passes_gradients_through() {
+    Tape::reset();
+    let w = Tensor::new(vec![1.0, 2.0, 3.0], &[3]).requires_grad();
+    let narrow = w.to_dtype(DType::BF16);
+    narrow.backward();
+
+    assert_eq!(w.grad_ref().unwrap().as_slice(), &[1.0, 1.0, 1.0]);
+}
+
+/// `data()` hands out a raw f32 slice, which only makes sense for f32 storage.
+#[test]
+#[should_panic(expected = "needs f32 storage")]
+fn raw_f32_access_to_narrow_storage_is_rejected() {
+    let t = Tensor::new(vec![1.0, 2.0], &[2]).to_dtype(DType::BF16);
+    drop(t.data());
+}
+
+#[test]
+fn casting_to_the_same_dtype_is_a_no_op() {
+    let t = Tensor::new(vec![1.0, 2.0], &[2]);
+    let same = t.to_dtype(DType::F32);
+    assert_eq!(same.to_vec(), t.to_vec());
+    assert_eq!(same.dtype(), DType::F32);
+}
+
+#[test]
+fn narrow_views_still_read_in_logical_order() {
+    let t = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]).to_dtype(DType::F16);
+    let viewed = t.transpose();
+
+    assert_eq!(viewed.dtype(), DType::F16);
+    assert_eq!(viewed.to_vec(), vec![0.0, 3.0, 1.0, 4.0, 2.0, 5.0]);
+}


### PR DESCRIPTION
Completes Tier 0 (after #12 strided tensors, #14 broadcasting + autograd graph).

Storage becomes an enum over `f32`/`bf16`/`f16`/`i32`/`u8`. Computation is
unchanged — ops read through `elements()`, which widens whatever the buffer
holds, so a narrow tensor takes part in arithmetic with no special casing.

What this buys:
- **Smaller storage**: bf16/f16 halve it, u8 quarters it.
- **Integer tensors**: labels and masks are representable rather than being
  floats that happen to hold whole numbers.
- The foundation mixed precision needs, without rewriting every kernel.

`data()`/`data_mut()` hand out a raw f32 slice, so they now assert dtype as well
as layout and report which of the two is wrong. `to_dtype()` casts with a
straight-through backward, since the cast is element-wise with unit derivative.

112 tests, clippy clean, MLP epoch time unchanged at 0.25s.