### PR TITLE
Add safetensors read/write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "reqwest",
+ "serde_json",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ blas-src   = { version = "0.10", default-features = false, optional = true } # v
 openblas-src = { version = "0.10", default-features = false, features = ["system"], optional = true }
 rayon = { version = "1.10" }
 lazy_static = "1.4"
+# Already in the tree via reqwest; used for the safetensors JSON header.
+serde_json = "1"
 
 [features]
 # Default: pure-Rust GEMM (matrixmultiply)
@@ -37,4 +39,5 @@ blas-accelerate = ["blas", "blas-src/accelerate"] # macOS Accelerate
 
 [dev-dependencies]
 criterion = "0.5"
+serde_json = "1"
 approx = "0.5"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ let predictions = model.forward(&inputs);
 
 `Tape::reset()` clears the recorded graph between training steps.
 
+## Saving and loading
+
+Models serialize to [safetensors](https://github.com/huggingface/safetensors),
+so weights interoperate with the wider ecosystem:
+
+```rust
+use taper::{Tensor, safetensors};
+
+safetensors::save(&[("weight", &w), ("bias", &b)], "model.safetensors")?;
+
+let loaded = safetensors::load("model.safetensors")?;
+assert_eq!(loaded["weight"].shape(), &[128, 784]);
+```
+
+Whole modules work too, with parameters named by position:
+
+```rust
+safetensors::save_module(&model, "model.safetensors")?;
+safetensors::load_module(&model, "model.safetensors")?;
+```
+
+`F32`, `BF16`, `F16`, `I32` and `U8` round-trip exactly. Wider dtypes found in
+other tools' checkpoints are narrowed on read — `F64` to `f32`, and
+`I64`/`U64`/`U32` to `i32`. Malformed files (overlapping tensors, gaps in the
+data buffer, a span that disagrees with its shape) are rejected rather than
+silently producing wrong weights.
+
 ## Quantization
 
 Storage quantization for model compression. Weights are stored quantized and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod nn;
 pub mod ops;
 pub mod optim;
 pub mod quantization;
+pub mod safetensors;
 pub mod tape;
 pub mod tensor;
 pub mod train;

--- a/src/safetensors.rs
+++ b/src/safetensors.rs
@@ -1,0 +1,434 @@
+//! Read and write the [safetensors] file format.
+//!
+//! The layout is: an 8-byte little-endian `u64` header length, that many bytes
+//! of UTF-8 JSON describing each tensor, then one contiguous byte buffer the
+//! JSON indexes into. All numbers are little-endian and tensors are row-major.
+//!
+//! ```no_run
+//! use taper::{Tensor, safetensors};
+//!
+//! let w = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
+//! safetensors::save(&[("weight", &w)], "model.safetensors")?;
+//!
+//! let loaded = safetensors::load("model.safetensors")?;
+//! assert_eq!(loaded["weight"].to_vec(), w.to_vec());
+//! # Ok::<(), safetensors::Error>(())
+//! ```
+//!
+//! [safetensors]: https://github.com/huggingface/safetensors
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::Path;
+
+use serde_json::{Map, Value, json};
+
+use crate::nn::Module;
+use crate::tensor::{DType, Storage, Tensor};
+
+/// The reserved header key holding free-form string-to-string metadata.
+const METADATA_KEY: &str = "__metadata__";
+
+/// Upper bound on the JSON header, matching the reference implementation's
+/// guard against a declared length that would force a huge allocation.
+const MAX_HEADER_BYTES: u64 = 100_000_000;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(std::io::Error),
+    /// The file is not a well-formed safetensors document.
+    Format(String),
+    /// A dtype this crate cannot represent.
+    UnsupportedDType(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Io(e) => write!(f, "safetensors io error: {e}"),
+            Error::Format(m) => write!(f, "malformed safetensors file: {m}"),
+            Error::UnsupportedDType(d) => write!(f, "unsupported safetensors dtype: {d}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Io(e)
+    }
+}
+
+fn malformed(msg: impl Into<String>) -> Error {
+    Error::Format(msg.into())
+}
+
+/// The format's name for a dtype we can write.
+fn dtype_name(dtype: DType) -> &'static str {
+    match dtype {
+        DType::F32 => "F32",
+        DType::BF16 => "BF16",
+        DType::F16 => "F16",
+        DType::I32 => "I32",
+        DType::U8 => "U8",
+    }
+}
+
+/// How a dtype in a file maps onto one of ours, and its width on disk.
+///
+/// Types wider than anything we hold are narrowed on read rather than rejected,
+/// because they are common in real checkpoints — `I64` token ids and `F64`
+/// weights especially. The conversion is documented on [`load`].
+fn read_plan(name: &str) -> Result<(usize, DType), Error> {
+    Ok(match name {
+        "F32" => (4, DType::F32),
+        "BF16" => (2, DType::BF16),
+        "F16" => (2, DType::F16),
+        "I32" => (4, DType::I32),
+        "U8" => (1, DType::U8),
+        "F64" => (8, DType::F32),
+        "I64" | "U64" => (8, DType::I32),
+        "U32" => (4, DType::I32),
+        "I16" | "U16" => (2, DType::I32),
+        "I8" => (1, DType::I32),
+        "BOOL" => (1, DType::U8),
+        other => return Err(Error::UnsupportedDType(other.to_string())),
+    })
+}
+
+/// Append a dense buffer's little-endian bytes.
+fn write_storage(out: &mut Vec<u8>, storage: &Storage) {
+    match storage {
+        Storage::F32(v) => v
+            .iter()
+            .for_each(|x| out.extend_from_slice(&x.to_le_bytes())),
+        Storage::BF16(v) | Storage::F16(v) => v
+            .iter()
+            .for_each(|x| out.extend_from_slice(&x.to_le_bytes())),
+        Storage::I32(v) => v
+            .iter()
+            .for_each(|x| out.extend_from_slice(&x.to_le_bytes())),
+        Storage::U8(v) => out.extend_from_slice(v),
+    }
+}
+
+/// Decode `count` elements of `name`'s type from little-endian `bytes`.
+fn read_storage(bytes: &[u8], name: &str, count: usize) -> Result<Storage, Error> {
+    let (width, dtype) = read_plan(name)?;
+    debug_assert_eq!(bytes.len(), count * width);
+
+    let chunks = bytes.chunks_exact(width);
+    Ok(match (name, dtype) {
+        ("F32", _) => Storage::F32(
+            chunks
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect(),
+        ),
+        ("BF16", _) => Storage::BF16(chunks.map(|c| u16::from_le_bytes([c[0], c[1]])).collect()),
+        ("F16", _) => Storage::F16(chunks.map(|c| u16::from_le_bytes([c[0], c[1]])).collect()),
+        ("I32", _) => Storage::I32(
+            chunks
+                .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect(),
+        ),
+        ("U8", _) | ("BOOL", _) => Storage::U8(bytes.to_vec()),
+        // Narrowed on read; see `read_plan`.
+        ("F64", _) => Storage::F32(
+            chunks
+                .map(|c| {
+                    f64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]) as f32
+                })
+                .collect(),
+        ),
+        ("I64", _) => Storage::I32(
+            chunks
+                .map(|c| {
+                    i64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]) as i32
+                })
+                .collect(),
+        ),
+        ("U64", _) => Storage::I32(
+            chunks
+                .map(|c| {
+                    u64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]) as i32
+                })
+                .collect(),
+        ),
+        ("U32", _) => Storage::I32(
+            chunks
+                .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]) as i32)
+                .collect(),
+        ),
+        ("I16", _) => Storage::I32(
+            chunks
+                .map(|c| i16::from_le_bytes([c[0], c[1]]) as i32)
+                .collect(),
+        ),
+        ("U16", _) => Storage::I32(
+            chunks
+                .map(|c| u16::from_le_bytes([c[0], c[1]]) as i32)
+                .collect(),
+        ),
+        ("I8", _) => Storage::I32(bytes.iter().map(|&b| b as i8 as i32).collect()),
+        (other, _) => return Err(Error::UnsupportedDType(other.to_string())),
+    })
+}
+
+/// Write named tensors to `path`.
+///
+/// Each tensor is serialized in its own dtype and in row-major logical order,
+/// so views are materialized rather than reinterpreted.
+pub fn save<P: AsRef<Path>>(tensors: &[(&str, &Tensor)], path: P) -> Result<(), Error> {
+    save_with_metadata(tensors, &BTreeMap::new(), path)
+}
+
+/// Like [`save`], plus a free-form string-to-string metadata map.
+pub fn save_with_metadata<P: AsRef<Path>>(
+    tensors: &[(&str, &Tensor)],
+    metadata: &BTreeMap<String, String>,
+    path: P,
+) -> Result<(), Error> {
+    let mut header = Map::new();
+    if !metadata.is_empty() {
+        let entries: Map<String, Value> = metadata
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect();
+        header.insert(METADATA_KEY.to_string(), Value::Object(entries));
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    for (name, _) in tensors {
+        if *name == METADATA_KEY {
+            return Err(malformed(format!(
+                "{METADATA_KEY} is a reserved tensor name"
+            )));
+        }
+        if !seen.insert(*name) {
+            return Err(malformed(format!("duplicate tensor name {name:?}")));
+        }
+    }
+
+    // serde_json orders header keys by name. Laying the buffer out in that same
+    // order keeps header order and offset order in agreement, so the file reads
+    // correctly whether a consumer checks contiguity as-listed or by offset.
+    let mut ordered: Vec<(&str, &Tensor)> = tensors.to_vec();
+    ordered.sort_by_key(|(name, _)| *name);
+
+    let mut buffer: Vec<u8> = Vec::new();
+    for (name, tensor) in &ordered {
+        let begin = buffer.len();
+        write_storage(&mut buffer, &tensor.to_storage());
+
+        header.insert(
+            (*name).to_string(),
+            json!({
+                "dtype": dtype_name(tensor.dtype()),
+                "shape": tensor.shape(),
+                // Offsets are relative to the start of the data buffer, not the file.
+                "data_offsets": [begin, buffer.len()],
+            }),
+        );
+    }
+
+    let header_bytes = serde_json::to_vec(&Value::Object(header))
+        .map_err(|e| malformed(format!("could not encode header: {e}")))?;
+
+    let mut file = BufWriter::new(File::create(path)?);
+    file.write_all(&(header_bytes.len() as u64).to_le_bytes())?;
+    file.write_all(&header_bytes)?;
+    file.write_all(&buffer)?;
+    file.flush()?;
+    Ok(())
+}
+
+/// Read every tensor from `path`, keyed by name.
+///
+/// Dtypes this crate stores natively (`F32`, `BF16`, `F16`, `I32`, `U8`) load
+/// exactly. Wider ones are narrowed — `F64` to `f32`, and `I64`/`U64`/`U32` to
+/// `i32`, which wraps for values outside `i32`'s range.
+pub fn load<P: AsRef<Path>>(path: P) -> Result<BTreeMap<String, Tensor>, Error> {
+    Ok(load_ordered(path)?.into_iter().collect())
+}
+
+/// Like [`load`], but preserving the order tensors appear in the header.
+pub fn load_ordered<P: AsRef<Path>>(path: P) -> Result<Vec<(String, Tensor)>, Error> {
+    let mut file = File::open(path)?;
+
+    let mut len_bytes = [0u8; 8];
+    file.read_exact(&mut len_bytes)
+        .map_err(|_| malformed("file is shorter than the 8-byte header length"))?;
+    let header_len = u64::from_le_bytes(len_bytes);
+
+    if header_len > MAX_HEADER_BYTES {
+        return Err(malformed(format!(
+            "header claims {header_len} bytes, above the {MAX_HEADER_BYTES} limit"
+        )));
+    }
+
+    let mut header_bytes = vec![0u8; header_len as usize];
+    file.read_exact(&mut header_bytes)
+        .map_err(|_| malformed("header is shorter than its declared length"))?;
+
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+
+    let header: Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| malformed(format!("header is not valid JSON: {e}")))?;
+    let header = header
+        .as_object()
+        .ok_or_else(|| malformed("header is not a JSON object"))?;
+
+    let mut out = Vec::new();
+    // Track coverage so a file with holes or overlaps is rejected rather than
+    // silently yielding tensors that alias each other.
+    let mut spans: Vec<(usize, usize, String)> = Vec::new();
+
+    for (name, entry) in header {
+        if name == METADATA_KEY {
+            continue;
+        }
+        let entry = entry
+            .as_object()
+            .ok_or_else(|| malformed(format!("entry {name:?} is not an object")))?;
+
+        let dtype_name = entry
+            .get("dtype")
+            .and_then(Value::as_str)
+            .ok_or_else(|| malformed(format!("entry {name:?} has no dtype")))?;
+
+        let shape: Vec<usize> = entry
+            .get("shape")
+            .and_then(Value::as_array)
+            .ok_or_else(|| malformed(format!("entry {name:?} has no shape")))?
+            .iter()
+            .map(|v| {
+                v.as_u64()
+                    .map(|d| d as usize)
+                    .ok_or_else(|| malformed(format!("entry {name:?} has a non-integer dimension")))
+            })
+            .collect::<Result<_, _>>()?;
+
+        let offsets = entry
+            .get("data_offsets")
+            .and_then(Value::as_array)
+            .filter(|o| o.len() == 2)
+            .ok_or_else(|| malformed(format!("entry {name:?} has no [begin, end] data_offsets")))?;
+        let begin = offsets[0]
+            .as_u64()
+            .ok_or_else(|| malformed(format!("entry {name:?} has a non-integer offset")))?
+            as usize;
+        let end = offsets[1]
+            .as_u64()
+            .ok_or_else(|| malformed(format!("entry {name:?} has a non-integer offset")))?
+            as usize;
+
+        if end < begin || end > buffer.len() {
+            return Err(malformed(format!(
+                "entry {name:?} spans [{begin}, {end}) outside the {}-byte buffer",
+                buffer.len()
+            )));
+        }
+
+        let (width, _) = read_plan(dtype_name)?;
+        let count: usize = shape.iter().product();
+        if end - begin != count * width {
+            return Err(malformed(format!(
+                "entry {name:?} spans {} bytes but shape {shape:?} of {dtype_name} needs {}",
+                end - begin,
+                count * width
+            )));
+        }
+
+        let storage = read_storage(&buffer[begin..end], dtype_name, count)?;
+        out.push((name.clone(), Tensor::from_storage(storage, &shape)));
+        spans.push((begin, end, name.clone()));
+    }
+
+    // The spec requires the buffer to be entirely indexed, with no holes and no
+    // overlaps. Checking it here turns a corrupt file into an error instead of
+    // silently wrong weights.
+    spans.sort_by_key(|(begin, _, _)| *begin);
+    let mut cursor = 0usize;
+    for (begin, end, name) in &spans {
+        if *begin < cursor {
+            return Err(malformed(format!(
+                "entry {name:?} overlaps an earlier tensor"
+            )));
+        }
+        if *begin > cursor {
+            return Err(malformed(format!(
+                "gap of {} bytes in the data buffer before {name:?}",
+                begin - cursor
+            )));
+        }
+        cursor = *end;
+    }
+    if cursor != buffer.len() {
+        return Err(malformed(format!(
+            "{} trailing bytes are not indexed by any tensor",
+            buffer.len() - cursor
+        )));
+    }
+
+    // Header order is whatever the writer chose; sort so callers get a stable
+    // sequence regardless of the JSON object's ordering.
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Save a module's parameters, named by their position in `parameters()`.
+///
+/// The trait exposes no names, so these are positional (`param.0`, `param.1`,
+/// …) and only reload into a module with the same structure. Use [`save`]
+/// directly when you have real names to attach.
+pub fn save_module<P: AsRef<Path>>(module: &dyn Module, path: P) -> Result<(), Error> {
+    let params = module.parameters();
+    let names: Vec<String> = (0..params.len()).map(|i| format!("param.{i}")).collect();
+    let entries: Vec<(&str, &Tensor)> = names
+        .iter()
+        .map(String::as_str)
+        .zip(params.iter())
+        .collect();
+    save(&entries, path)
+}
+
+/// Load parameters written by [`save_module`] back into a module.
+pub fn load_module<P: AsRef<Path>>(module: &dyn Module, path: P) -> Result<(), Error> {
+    let loaded = load(path)?;
+    let params = module.parameters();
+
+    if loaded.len() != params.len() {
+        return Err(malformed(format!(
+            "file holds {} tensors but the module has {} parameters",
+            loaded.len(),
+            params.len()
+        )));
+    }
+
+    for (i, param) in params.iter().enumerate() {
+        let name = format!("param.{i}");
+        let source = loaded
+            .get(&name)
+            .ok_or_else(|| malformed(format!("file has no tensor named {name:?}")))?;
+
+        if source.shape() != param.shape() {
+            return Err(malformed(format!(
+                "{name} has shape {:?} but the module expects {:?}",
+                source.shape(),
+                param.shape()
+            )));
+        }
+        param.data_mut().copy_from_slice(&source.to_vec());
+    }
+    Ok(())
+}

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -288,7 +288,7 @@ impl DType {
 }
 
 /// A tensor's backing buffer, in one of the supported element types.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Storage {
     F32(Vec<f32>),
     BF16(Vec<u16>),
@@ -1108,25 +1108,19 @@ impl Tensor {
         }
     }
 
-    /// This tensor's logical elements in row-major order.
+    /// Visit each logical position's index into the backing storage, in
+    /// row-major order.
     ///
-    /// Walks the strides, so it is correct for any view; the contiguous case
-    /// short-circuits to a plain clone.
-    pub fn to_vec(&self) -> Vec<f32> {
-        let storage = self.data.read().expect("data RwLock poisoned");
-        if self.offset == 0 && self.is_contiguous() && storage.len() == self.numel() {
-            return storage.to_f32_vec();
-        }
-
+    /// Odometer walk: advance the fastest-varying dimension, carrying over.
+    #[inline]
+    fn for_each_storage_index(&self, mut visit: impl FnMut(usize)) {
         let n = self.numel();
-        let mut out = Vec::with_capacity(n);
         let ndim = self.shape.len();
         let mut index = vec![0usize; ndim];
         let mut cursor = self.offset;
 
-        // Odometer walk: advance the fastest-varying dimension, carrying over.
         for _ in 0..n {
-            out.push(storage.get_f32(cursor));
+            visit(cursor);
             for d in (0..ndim).rev() {
                 index[d] += 1;
                 cursor += self.stride[d];
@@ -1137,7 +1131,50 @@ impl Tensor {
                 index[d] = 0;
             }
         }
+    }
+
+    /// Whether this tensor is exactly its backing buffer, in order.
+    #[inline]
+    fn is_dense(&self, storage: &Storage) -> bool {
+        self.offset == 0 && self.is_contiguous() && storage.len() == self.numel()
+    }
+
+    /// This tensor's logical elements in row-major order, widened to `f32`.
+    ///
+    /// Walks the strides, so it is correct for any view; the contiguous case
+    /// short-circuits to a plain clone.
+    pub fn to_vec(&self) -> Vec<f32> {
+        let storage = self.data.read().expect("data RwLock poisoned");
+        if self.is_dense(&storage) {
+            return storage.to_f32_vec();
+        }
+
+        let mut out = Vec::with_capacity(self.numel());
+        self.for_each_storage_index(|i| out.push(storage.get_f32(i)));
         out
+    }
+
+    /// This tensor's logical elements as a dense buffer **in its own dtype**.
+    ///
+    /// Unlike [`Tensor::to_vec`] this does not widen, so an `i32` tensor keeps
+    /// values `f32` could not represent exactly — which is what serialization
+    /// needs.
+    pub fn to_storage(&self) -> Storage {
+        let storage = self.data.read().expect("data RwLock poisoned");
+        if self.is_dense(&storage) {
+            return storage.clone();
+        }
+
+        let mut indices = Vec::with_capacity(self.numel());
+        self.for_each_storage_index(|i| indices.push(i));
+
+        match &*storage {
+            Storage::F32(v) => Storage::F32(indices.iter().map(|&i| v[i]).collect()),
+            Storage::BF16(v) => Storage::BF16(indices.iter().map(|&i| v[i]).collect()),
+            Storage::F16(v) => Storage::F16(indices.iter().map(|&i| v[i]).collect()),
+            Storage::I32(v) => Storage::I32(indices.iter().map(|&i| v[i]).collect()),
+            Storage::U8(v) => Storage::U8(indices.iter().map(|&i| v[i]).collect()),
+        }
     }
 
     /// A densely packed tensor with the same logical contents.

--- a/src/train.rs
+++ b/src/train.rs
@@ -280,7 +280,23 @@ impl Trainer {
         self.metrics.plot_summary();
     }
 
-    /// Save model checkpoint.
+    /// Save the model's parameters as a safetensors file.
+    ///
+    /// Prefer this over [`Trainer::save_checkpoint`]: it is compact, exact, and
+    /// readable by any other safetensors implementation.
+    pub fn save_safetensors(&self, path: &str) -> Result<(), crate::safetensors::Error> {
+        crate::safetensors::save_module(self.model.as_ref(), path)
+    }
+
+    /// Load parameters from a safetensors file written by [`Trainer::save_safetensors`].
+    pub fn load_safetensors(&mut self, path: &str) -> Result<(), crate::safetensors::Error> {
+        crate::safetensors::load_module(self.model.as_ref(), path)
+    }
+
+    /// Save model checkpoint in a plain-text format.
+    ///
+    /// Kept for compatibility; [`Trainer::save_safetensors`] is smaller, exact,
+    /// and interoperable.
     ///
     /// Format: parameter count, then per parameter a shape line
     /// (`rank dim0 dim1 …`) followed by one value per line.

--- a/tests/safetensors.rs
+++ b/tests/safetensors.rs
@@ -1,0 +1,325 @@
+//! safetensors round-trips, plus conformance against hand-built bytes.
+//!
+//! The reference Python implementation is not assumed to be installed, so the
+//! format is pinned by constructing files byte-by-byte from the spec.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use taper::Tensor;
+use taper::nn::{Linear, Module, Sequential};
+use taper::safetensors;
+use taper::tensor::{DType, Storage};
+
+fn scratch(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "taper_st_{name}_{}.safetensors",
+        std::process::id()
+    ));
+    p
+}
+
+/// Assemble a file exactly as the spec describes: 8-byte little-endian header
+/// length, the JSON header, then the data buffer.
+fn write_raw(path: &std::path::Path, header: &str, data: &[u8]) {
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(&(header.len() as u64).to_le_bytes()).unwrap();
+    f.write_all(header.as_bytes()).unwrap();
+    f.write_all(data).unwrap();
+}
+
+#[test]
+fn reads_a_hand_built_file() {
+    let path = scratch("handbuilt");
+    let header = r#"{"x":{"dtype":"F32","shape":[2,2],"data_offsets":[0,16]}}"#;
+    let mut data = Vec::new();
+    for v in [1.0f32, 2.0, 3.0, 4.0] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    write_raw(&path, header, &data);
+
+    let loaded = safetensors::load(&path).unwrap();
+    assert_eq!(loaded.len(), 1);
+    let x = &loaded["x"];
+    assert_eq!(x.shape(), &[2, 2]);
+    assert_eq!(x.dtype(), DType::F32);
+    assert_eq!(x.to_vec(), vec![1.0, 2.0, 3.0, 4.0]);
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// What we write must match the spec's byte layout, not merely be readable by us.
+#[test]
+fn writes_the_documented_byte_layout() {
+    let path = scratch("layout");
+    let t = Tensor::new(vec![1.0, 2.0], &[2]);
+    safetensors::save(&[("w", &t)], &path).unwrap();
+
+    let bytes = std::fs::read(&path).unwrap();
+    let header_len = u64::from_le_bytes(bytes[0..8].try_into().unwrap()) as usize;
+
+    // The header is UTF-8 JSON and must start with '{'.
+    let header = std::str::from_utf8(&bytes[8..8 + header_len]).unwrap();
+    assert!(header.starts_with('{'), "header must open with a brace");
+
+    let parsed: serde_json::Value = serde_json::from_str(header).unwrap();
+    let entry = &parsed["w"];
+    assert_eq!(entry["dtype"], "F32");
+    assert_eq!(entry["shape"], serde_json::json!([2]));
+    assert_eq!(entry["data_offsets"], serde_json::json!([0, 8]));
+
+    // Offsets are relative to the buffer, which starts after the header.
+    let buffer = &bytes[8 + header_len..];
+    assert_eq!(buffer.len(), 8);
+    assert_eq!(f32::from_le_bytes(buffer[0..4].try_into().unwrap()), 1.0);
+    assert_eq!(f32::from_le_bytes(buffer[4..8].try_into().unwrap()), 2.0);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn round_trips_every_native_dtype() {
+    let path = scratch("dtypes");
+    let base = Tensor::new(vec![-1.5, 0.0, 0.5, 2.0], &[4]);
+
+    let f32_t = base.clone();
+    let bf16_t = base.to_dtype(DType::BF16);
+    let f16_t = base.to_dtype(DType::F16);
+    let i32_t = Tensor::from_storage(Storage::I32(vec![-5, 0, 7, 100000]), &[4]);
+    let u8_t = Tensor::from_storage(Storage::U8(vec![0, 1, 200, 255]), &[4]);
+
+    safetensors::save(
+        &[
+            ("f32", &f32_t),
+            ("bf16", &bf16_t),
+            ("f16", &f16_t),
+            ("i32", &i32_t),
+            ("u8", &u8_t),
+        ],
+        &path,
+    )
+    .unwrap();
+
+    let loaded = safetensors::load(&path).unwrap();
+    assert_eq!(loaded.len(), 5);
+
+    // Dtypes survive; values are bit-identical because nothing is re-narrowed.
+    assert_eq!(loaded["f32"].dtype(), DType::F32);
+    assert_eq!(loaded["f32"].to_vec(), f32_t.to_vec());
+    assert_eq!(loaded["bf16"].dtype(), DType::BF16);
+    assert_eq!(loaded["bf16"].to_vec(), bf16_t.to_vec());
+    assert_eq!(loaded["f16"].dtype(), DType::F16);
+    assert_eq!(loaded["f16"].to_vec(), f16_t.to_vec());
+
+    // 100000 exceeds f32's exactly-representable integers only above 2^24, but
+    // the point is that i32 never round-trips through f32 on the way out.
+    assert_eq!(loaded["i32"].dtype(), DType::I32);
+    assert_eq!(loaded["i32"].to_vec(), vec![-5.0, 0.0, 7.0, 100000.0]);
+    assert_eq!(loaded["u8"].dtype(), DType::U8);
+    assert_eq!(loaded["u8"].to_vec(), vec![0.0, 1.0, 200.0, 255.0]);
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// i32 values beyond f32's exact integer range must survive, which they only do
+/// because serialization goes through the storage rather than to_vec().
+#[test]
+fn large_integers_survive_the_round_trip() {
+    let path = scratch("bigint");
+    let big = 16_777_217i32; // 2^24 + 1, the first integer f32 cannot represent
+    let t = Tensor::from_storage(Storage::I32(vec![big, -big]), &[2]);
+    safetensors::save(&[("ids", &t)], &path).unwrap();
+
+    let loaded = safetensors::load(&path).unwrap();
+    match loaded["ids"].to_storage() {
+        Storage::I32(v) => assert_eq!(v.as_slice(), &[big, -big]),
+        other => panic!("expected i32 storage, got {:?}", other.dtype()),
+    }
+
+    std::fs::remove_file(&path).ok();
+}
+
+/// Tensors are serialized in row-major logical order, so a view is materialized
+/// rather than having its base's buffer written out.
+#[test]
+fn views_are_written_in_logical_order() {
+    let path = scratch("views");
+    let base = Tensor::new((0..6).map(|i| i as f32).collect(), &[2, 3]);
+    let view = base.transpose();
+    assert!(!view.is_contiguous());
+
+    safetensors::save(&[("t", &view)], &path).unwrap();
+    let loaded = safetensors::load(&path).unwrap();
+
+    assert_eq!(loaded["t"].shape(), &[3, 2]);
+    assert_eq!(loaded["t"].to_vec(), vec![0.0, 3.0, 1.0, 4.0, 2.0, 5.0]);
+    assert!(loaded["t"].is_contiguous());
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn metadata_round_trips_and_is_not_a_tensor() {
+    let path = scratch("meta");
+    let t = Tensor::new(vec![1.0], &[1]);
+    let mut meta = BTreeMap::new();
+    meta.insert("format".to_string(), "taper".to_string());
+
+    safetensors::save_with_metadata(&[("w", &t)], &meta, &path).unwrap();
+
+    let bytes = std::fs::read(&path).unwrap();
+    let header_len = u64::from_le_bytes(bytes[0..8].try_into().unwrap()) as usize;
+    let parsed: serde_json::Value = serde_json::from_slice(&bytes[8..8 + header_len]).unwrap();
+    assert_eq!(parsed["__metadata__"]["format"], "taper");
+
+    // __metadata__ must not come back as a tensor.
+    let loaded = safetensors::load(&path).unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert!(loaded.contains_key("w"));
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn wider_dtypes_are_narrowed_on_read() {
+    let path = scratch("wide");
+    // An F64 tensor and an I64 tensor, as produced by numpy/torch checkpoints.
+    let header = r#"{"a":{"dtype":"F64","shape":[2],"data_offsets":[0,16]},"b":{"dtype":"I64","shape":[2],"data_offsets":[16,32]}}"#;
+    let mut data = Vec::new();
+    for v in [1.5f64, -2.25] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    for v in [7i64, -9] {
+        data.extend_from_slice(&v.to_le_bytes());
+    }
+    write_raw(&path, header, &data);
+
+    let loaded = safetensors::load(&path).unwrap();
+    assert_eq!(loaded["a"].dtype(), DType::F32);
+    assert_eq!(loaded["a"].to_vec(), vec![1.5, -2.25]);
+    assert_eq!(loaded["b"].dtype(), DType::I32);
+    assert_eq!(loaded["b"].to_vec(), vec![7.0, -9.0]);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn module_parameters_round_trip() {
+    let path = scratch("module");
+    let model = Sequential::new(vec![
+        Box::new(Linear::new(4, 3, true)),
+        Box::new(Linear::new(3, 2, true)),
+    ]);
+    let before: Vec<Vec<f32>> = model.parameters().iter().map(|p| p.to_vec()).collect();
+
+    safetensors::save_module(&model, &path).unwrap();
+
+    // A structurally identical model with different random weights.
+    let other = Sequential::new(vec![
+        Box::new(Linear::new(4, 3, true)),
+        Box::new(Linear::new(3, 2, true)),
+    ]);
+    assert_ne!(other.parameters()[0].to_vec(), before[0]);
+
+    safetensors::load_module(&other, &path).unwrap();
+    let after: Vec<Vec<f32>> = other.parameters().iter().map(|p| p.to_vec()).collect();
+    assert_eq!(after, before);
+
+    // A differently shaped model is refused rather than silently mis-loaded.
+    let wrong = Sequential::new(vec![Box::new(Linear::new(8, 3, true))]);
+    assert!(safetensors::load_module(&wrong, &path).is_err());
+
+    std::fs::remove_file(&path).ok();
+}
+
+// --- malformed files are rejected, not silently mis-read ---
+
+#[test]
+fn rejects_a_truncated_file() {
+    let path = scratch("truncated");
+    std::fs::write(&path, [0u8; 4]).unwrap();
+    assert!(safetensors::load(&path).is_err());
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_an_absurd_header_length() {
+    let path = scratch("hugeheader");
+    let mut f = std::fs::File::create(&path).unwrap();
+    // Declaring a giant header would otherwise force a giant allocation.
+    f.write_all(&u64::MAX.to_le_bytes()).unwrap();
+    drop(f);
+
+    let err = safetensors::load(&path).unwrap_err().to_string();
+    assert!(err.contains("limit"), "unexpected error: {err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_offsets_that_leave_a_hole() {
+    let path = scratch("hole");
+    // 4 bytes of padding between the two tensors: the buffer is not fully indexed.
+    let header = r#"{"a":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},"b":{"dtype":"F32","shape":[1],"data_offsets":[8,12]}}"#;
+    write_raw(&path, header, &[0u8; 12]);
+
+    let err = safetensors::load(&path).unwrap_err().to_string();
+    assert!(err.contains("gap"), "unexpected error: {err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_overlapping_tensors() {
+    let path = scratch("overlap");
+    let header = r#"{"a":{"dtype":"F32","shape":[2],"data_offsets":[0,8]},"b":{"dtype":"F32","shape":[1],"data_offsets":[4,8]}}"#;
+    write_raw(&path, header, &[0u8; 8]);
+
+    let err = safetensors::load(&path).unwrap_err().to_string();
+    assert!(err.contains("overlap"), "unexpected error: {err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_a_span_that_disagrees_with_the_shape() {
+    let path = scratch("badlen");
+    // shape [4] of F32 needs 16 bytes, but only 8 are claimed.
+    let header = r#"{"a":{"dtype":"F32","shape":[4],"data_offsets":[0,8]}}"#;
+    write_raw(&path, header, &[0u8; 8]);
+
+    let err = safetensors::load(&path).unwrap_err().to_string();
+    assert!(err.contains("needs"), "unexpected error: {err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_offsets_past_the_end_of_the_buffer() {
+    let path = scratch("oob");
+    let header = r#"{"a":{"dtype":"F32","shape":[4],"data_offsets":[0,16]}}"#;
+    write_raw(&path, header, &[0u8; 8]);
+
+    let err = safetensors::load(&path).unwrap_err().to_string();
+    assert!(err.contains("outside"), "unexpected error: {err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_an_unknown_dtype() {
+    let path = scratch("dtype");
+    let header = r#"{"a":{"dtype":"COMPLEX128","shape":[1],"data_offsets":[0,16]}}"#;
+    write_raw(&path, header, &[0u8; 16]);
+
+    let err = safetensors::load(&path).unwrap_err().to_string();
+    assert!(err.contains("unsupported"), "unexpected error: {err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn rejects_duplicate_and_reserved_names_on_write() {
+    let path = scratch("dup");
+    let t = Tensor::new(vec![1.0], &[1]);
+
+    assert!(safetensors::save(&[("w", &t), ("w", &t)], &path).is_err());
+    assert!(safetensors::save(&[("__metadata__", &t)], &path).is_err());
+
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
Tier 2's first item, and the one that most limits who can use taper today: the
only way to persist a model was a bespoke text format with no reader outside
this crate.

`taper::safetensors` implements the format directly — 8-byte little-endian
header length, JSON header, one contiguous little-endian data buffer, row-major.

- Tensors are written in **their own dtype** via `Tensor::to_storage()`, so an
  `i32` tensor keeps values `f32` cannot represent. Views are materialized in
  logical order rather than having their base's buffer written out.
- `F32`/`BF16`/`F16`/`I32`/`U8` round-trip exactly. `F64` and `I64`/`U64`/`U32`
  from other tools' checkpoints are narrowed on read.
- `__metadata__` is supported and never surfaces as a tensor.
- Header keys and data offsets are laid out in the same order, so the file is
  well-formed whether a consumer checks contiguity as-listed or by offset.

**Malformed files are rejected**, not silently mis-read: overlapping spans, gaps
in the buffer, a span that disagrees with its shape, offsets past the end,
oversized header lengths (the reference DOS guard), unknown dtypes, and
duplicate or reserved names on write.

Conformance is pinned by assembling files byte-by-byte from the spec, so the
tests don't depend on the Python implementation being installed.

`Trainer` gains `save_safetensors`/`load_safetensors`; the text checkpoint stays
for compatibility but is documented as superseded.

129 tests, clippy clean. `serde_json` was already in the tree via reqwest.