### PR TITLE
Train on any dataset, not just MNIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,43 @@ cargo run --release --features blas-accelerate --example train_mnist
 cargo run --release --features blas-accelerate --example train_mnist_cnn
 ```
 
+### Training on your own data
+
+Training works against the [`Dataset`] trait, not any particular dataset. For
+data already in memory, `TensorDataset` takes a stacked input tensor and a
+stacked target tensor — anything after the leading sample dimension is your
+feature shape, so `[N, features]` and `[N, C, H, W]` both work:
+
+```rust
+use taper::data::{DataLoader, TensorDataset};
+
+let dataset = TensorDataset::new(
+    Tensor::new(features, &[n_samples, n_features]),
+    Tensor::new(labels, &[n_samples]),
+);
+let mut loader = DataLoader::new(dataset, 32, true);
+
+trainer.fit(&mut loader, &mut val_loader, 10, true);
+```
+
+For data that does not fit in memory, or that needs decoding per batch,
+implement the trait directly:
+
+```rust
+impl Dataset for MyDataset {
+    fn len(&self) -> usize { self.rows.len() }
+
+    fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor) {
+        // gather these samples into (inputs, targets)
+    }
+}
+```
+
+Batching is a gather over indices rather than one sample at a time, so a whole
+batch can be assembled in a single pass.
+
+[`Dataset`]: https://docs.rs/taper/latest/taper/data/trait.Dataset.html
+
 ### Inference
 
 Forward passes record backward closures on a thread-local tape. Wrap inference

--- a/src/data/mnist.rs
+++ b/src/data/mnist.rs
@@ -1,4 +1,8 @@
 use crate::Tensor;
+use crate::data::Dataset;
+
+/// Re-exported for compatibility; `DataLoader` is generic over any [`Dataset`].
+pub use crate::data::DataLoader;
 use std::fs::{File, create_dir_all};
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
@@ -272,40 +276,9 @@ impl MNISTDataset {
         Ok(Tensor::new(labels, &[num_labels]))
     }
 
-    /// Get a batch of samples by indices (parallelized with Rayon)
-    pub fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor) {
-        let batch_size = indices.len();
-
-        // preallocate exact sizes
-        let mut batch_images = vec![0.0f32; batch_size * 784];
-        let mut batch_labels = vec![0.0f32; batch_size];
-
-        // hold read guards once
-        let images_data_guard = self.images.data();
-        let labels_data_guard = self.labels.data();
-        let images_data: &[f32] = &images_data_guard;
-        let labels_data: &[f32] = &labels_data_guard;
-
-        // copy images in parallel: each chunk writes to a disjoint [i*784 .. (i+1)*784)
-        batch_images
-            .par_chunks_mut(784)
-            .enumerate()
-            .for_each(|(i, dst)| {
-                let idx = indices[i];
-                let src = &images_data[idx * 784..idx * 784 + 784];
-                // safe: disjoint writes per i
-                dst.copy_from_slice(src);
-            });
-
-        // copy labels in parallel
-        batch_labels.par_iter_mut().enumerate().for_each(|(i, y)| {
-            *y = labels_data[indices[i]];
-        });
-
-        (
-            Tensor::new(batch_images, &[batch_size, 784]),
-            Tensor::new(batch_labels, &[batch_size]),
-        )
+    /// Number of pixels per image, taken from the data rather than assumed.
+    fn features(&self) -> usize {
+        self.images.shape()[1]
     }
 
     /// Get the size of the dataset
@@ -327,64 +300,40 @@ impl MNISTDataset {
     }
 }
 
-// Keep the DataLoader implementation the same as before
-pub struct DataLoader {
-    dataset: MNISTDataset,
-    batch_size: usize,
-    shuffle: bool,
-    indices: Vec<usize>,
-    current: usize,
-}
-
-impl DataLoader {
-    pub fn new(dataset: MNISTDataset, batch_size: usize, shuffle: bool) -> Self {
-        let n = dataset.len();
-        let mut indices: Vec<usize> = (0..n).collect();
-
-        if shuffle {
-            use rand::seq::SliceRandom;
-            let mut rng = rand::thread_rng();
-            indices.shuffle(&mut rng);
-        }
-
-        DataLoader {
-            dataset,
-            batch_size,
-            shuffle,
-            indices,
-            current: 0,
-        }
+impl Dataset for MNISTDataset {
+    fn len(&self) -> usize {
+        self.labels.shape()[0]
     }
 
-    pub fn reset(&mut self) {
-        self.current = 0;
+    /// Copies the batch in parallel; each destination chunk is disjoint.
+    fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor) {
+        let batch_size = indices.len();
+        let features = self.features();
 
-        if self.shuffle {
-            use rand::seq::SliceRandom;
-            let mut rng = rand::thread_rng();
-            self.indices.shuffle(&mut rng);
-        }
-    }
+        let mut batch_images = vec![0.0f32; batch_size * features];
+        let mut batch_labels = vec![0.0f32; batch_size];
 
-    pub fn num_batches(&self) -> usize {
-        self.dataset.len().div_ceil(self.batch_size)
-    }
-}
+        // hold read guards once
+        let images_data_guard = self.images.data();
+        let labels_data_guard = self.labels.data();
+        let images_data: &[f32] = &images_data_guard;
+        let labels_data: &[f32] = &labels_data_guard;
 
-impl Iterator for DataLoader {
-    type Item = (Tensor, Tensor);
+        batch_images
+            .par_chunks_mut(features)
+            .enumerate()
+            .for_each(|(i, dst)| {
+                let idx = indices[i];
+                dst.copy_from_slice(&images_data[idx * features..idx * features + features]);
+            });
 
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current >= self.dataset.len() {
-            return None;
-        }
+        batch_labels.par_iter_mut().enumerate().for_each(|(i, y)| {
+            *y = labels_data[indices[i]];
+        });
 
-        let end = (self.current + self.batch_size).min(self.dataset.len());
-        let batch_indices = &self.indices[self.current..end];
-
-        let batch = self.dataset.get_batch(batch_indices);
-        self.current = end;
-
-        Some(batch)
+        (
+            Tensor::new(batch_images, &[batch_size, features]),
+            Tensor::new(batch_labels, &[batch_size]),
+        )
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,1 +1,176 @@
+//! Datasets and batching.
+//!
+//! [`Dataset`] is the only thing training needs from your data. Implement it
+//! and every batching, shuffling and training utility in the crate works — see
+//! [`TensorDataset`] for the common case of data already in memory.
+
 pub mod mnist;
+
+use crate::Tensor;
+
+/// A finite, indexable collection of `(input, target)` samples.
+///
+/// Batching is expressed as a gather over indices rather than one sample at a
+/// time, so implementations can copy a whole batch in one pass — the MNIST one
+/// does it in parallel.
+pub trait Dataset {
+    /// Number of samples.
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Gather `indices` into a batch of `(inputs, targets)`.
+    ///
+    /// Both tensors must have `indices.len()` as their leading dimension.
+    fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor);
+}
+
+/// Data already resident in memory, as a pair of stacked tensors.
+///
+/// `inputs` and `targets` share a leading sample dimension; everything after it
+/// is per-sample and copied through unchanged, so any feature shape works —
+/// `[N, features]` for tabular data, `[N, C, H, W]` for images.
+///
+/// ```
+/// # use taper::{Tensor, data::{Dataset, TensorDataset}};
+/// let x = Tensor::new((0..12).map(|i| i as f32).collect(), &[4, 3]);
+/// let y = Tensor::new(vec![0.0, 1.0, 0.0, 1.0], &[4]);
+/// let dataset = TensorDataset::new(x, y);
+///
+/// let (bx, by) = dataset.get_batch(&[0, 2]);
+/// assert_eq!(bx.shape(), &[2, 3]);
+/// assert_eq!(by.shape(), &[2]);
+/// ```
+pub struct TensorDataset {
+    inputs: Tensor,
+    targets: Tensor,
+}
+
+impl TensorDataset {
+    /// # Panics
+    /// If the two tensors disagree on the number of samples.
+    pub fn new(inputs: Tensor, targets: Tensor) -> Self {
+        assert!(
+            !inputs.shape().is_empty() && !targets.shape().is_empty(),
+            "TensorDataset: inputs and targets need a leading sample dimension"
+        );
+        assert_eq!(
+            inputs.shape()[0],
+            targets.shape()[0],
+            "TensorDataset: {} inputs but {} targets",
+            inputs.shape()[0],
+            targets.shape()[0]
+        );
+        Self { inputs, targets }
+    }
+
+    pub fn inputs(&self) -> &Tensor {
+        &self.inputs
+    }
+
+    pub fn targets(&self) -> &Tensor {
+        &self.targets
+    }
+}
+
+/// Copy the samples at `indices` out of a stacked `[N, ...]` tensor.
+fn gather_samples(source: &Tensor, indices: &[usize]) -> Tensor {
+    let per_sample: usize = source.shape()[1..].iter().product();
+    let values = source.to_vec();
+
+    let mut out = Vec::with_capacity(indices.len() * per_sample);
+    for &i in indices {
+        let start = i * per_sample;
+        out.extend_from_slice(&values[start..start + per_sample]);
+    }
+
+    let mut shape = vec![indices.len()];
+    shape.extend_from_slice(&source.shape()[1..]);
+    Tensor::new(out, &shape)
+}
+
+impl Dataset for TensorDataset {
+    fn len(&self) -> usize {
+        self.inputs.shape()[0]
+    }
+
+    fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor) {
+        (
+            gather_samples(&self.inputs, indices),
+            gather_samples(&self.targets, indices),
+        )
+    }
+}
+
+/// Iterates a [`Dataset`] in batches, optionally reshuffling each epoch.
+///
+/// The final batch is short when the dataset does not divide evenly.
+pub struct DataLoader<D: Dataset> {
+    dataset: D,
+    batch_size: usize,
+    shuffle: bool,
+    indices: Vec<usize>,
+    current: usize,
+}
+
+impl<D: Dataset> DataLoader<D> {
+    /// # Panics
+    /// If `batch_size` is zero.
+    pub fn new(dataset: D, batch_size: usize, shuffle: bool) -> Self {
+        assert!(batch_size > 0, "DataLoader: batch_size must be non-zero");
+
+        let mut indices: Vec<usize> = (0..dataset.len()).collect();
+        if shuffle {
+            use rand::seq::SliceRandom;
+            indices.shuffle(&mut rand::thread_rng());
+        }
+
+        DataLoader {
+            dataset,
+            batch_size,
+            shuffle,
+            indices,
+            current: 0,
+        }
+    }
+
+    /// Rewind to the start, reshuffling if this loader shuffles.
+    pub fn reset(&mut self) {
+        self.current = 0;
+        if self.shuffle {
+            use rand::seq::SliceRandom;
+            self.indices.shuffle(&mut rand::thread_rng());
+        }
+    }
+
+    /// Number of batches per pass, counting a short final batch.
+    pub fn num_batches(&self) -> usize {
+        self.dataset.len().div_ceil(self.batch_size)
+    }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    pub fn dataset(&self) -> &D {
+        &self.dataset
+    }
+}
+
+impl<D: Dataset> Iterator for DataLoader<D> {
+    type Item = (Tensor, Tensor);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current >= self.dataset.len() {
+            return None;
+        }
+
+        let end = (self.current + self.batch_size).min(self.dataset.len());
+        let batch = self.dataset.get_batch(&self.indices[self.current..end]);
+        self.current = end;
+
+        Some(batch)
+    }
+}

--- a/src/train.rs
+++ b/src/train.rs
@@ -1,4 +1,4 @@
-use crate::data::mnist::DataLoader;
+use crate::data::{DataLoader, Dataset};
 use crate::loss::{correct_count, cross_entropy_loss};
 use crate::optim::{Adam, LRScheduler};
 use crate::{Tape, nn::Module};
@@ -99,7 +99,7 @@ impl Trainer {
     }
 
     /// Train for one epoch
-    pub fn train_epoch(&mut self, dataloader: &mut DataLoader) -> (f32, f32) {
+    pub fn train_epoch<D: Dataset>(&mut self, dataloader: &mut DataLoader<D>) -> (f32, f32) {
         let mut total_loss = 0.0;
         let mut total_correct = 0;
         let mut total_samples = 0;
@@ -148,7 +148,7 @@ impl Trainer {
     }
 
     /// Evaluate on validation/test set
-    pub fn evaluate(&self, dataloader: &mut DataLoader) -> (f32, f32) {
+    pub fn evaluate<D: Dataset>(&self, dataloader: &mut DataLoader<D>) -> (f32, f32) {
         let mut total_loss = 0.0;
         let mut total_correct = 0;
         let mut total_samples = 0;
@@ -184,10 +184,10 @@ impl Trainer {
     }
 
     /// Main training loop
-    pub fn fit(
+    pub fn fit<D: Dataset>(
         &mut self,
-        train_loader: &mut DataLoader,
-        val_loader: &mut DataLoader,
+        train_loader: &mut DataLoader<D>,
+        val_loader: &mut DataLoader<D>,
         epochs: usize,
         verbose: bool,
     ) {
@@ -403,10 +403,10 @@ impl Trainer {
 }
 
 /// Helper function to create and train a model quickly
-pub fn quick_train_mnist(
+pub fn quick_train_mnist<D: Dataset>(
     model: Box<dyn Module>,
-    train_loader: &mut DataLoader,
-    val_loader: &mut DataLoader,
+    train_loader: &mut DataLoader<D>,
+    val_loader: &mut DataLoader<D>,
     epochs: usize,
     learning_rate: f32,
 ) -> Metrics {
@@ -422,7 +422,11 @@ pub fn quick_train_mnist(
 }
 
 /// Utility function to test model on a few samples
-pub fn test_samples(model: &dyn Module, dataloader: &mut DataLoader, num_samples: usize) {
+pub fn test_samples<D: Dataset>(
+    model: &dyn Module,
+    dataloader: &mut DataLoader<D>,
+    num_samples: usize,
+) {
     println!("\nTesting on {} samples:", num_samples);
     println!("{}", "-".repeat(40));
 

--- a/tests/dataset.rs
+++ b/tests/dataset.rs
@@ -1,0 +1,200 @@
+//! Training on arbitrary data.
+//!
+//! `DataLoader` used to hold a concrete `MNISTDataset` and `Trainer` took only
+//! that type, so the crate's headline training API worked on exactly one
+//! dataset. These tests pin the general case.
+
+use std::collections::HashSet;
+
+use taper::Tensor;
+use taper::activation::ReLU;
+use taper::data::{DataLoader, Dataset, TensorDataset};
+use taper::nn::{Linear, Module, Sequential};
+use taper::optim::Adam;
+use taper::train::Trainer;
+
+/// A synthetic two-class problem with a feature width that is deliberately not 784.
+fn synthetic(samples: usize, features: usize) -> TensorDataset {
+    let mut x = Vec::with_capacity(samples * features);
+    let mut y = Vec::with_capacity(samples);
+
+    for i in 0..samples {
+        let positive = i % 2 == 0;
+        for f in 0..features {
+            // Two well-separated clusters, with a little deterministic jitter.
+            let base = if positive { 1.0 } else { -1.0 };
+            let jitter = ((i * 7 + f * 13) % 11) as f32 * 0.01;
+            x.push(base + jitter);
+        }
+        y.push(if positive { 1.0 } else { 0.0 });
+    }
+
+    TensorDataset::new(
+        Tensor::new(x, &[samples, features]),
+        Tensor::new(y, &[samples]),
+    )
+}
+
+#[test]
+fn tensor_dataset_handles_arbitrary_feature_widths() {
+    let dataset = synthetic(10, 5);
+    assert_eq!(dataset.len(), 10);
+
+    let (x, y) = dataset.get_batch(&[0, 3, 7]);
+    assert_eq!(x.shape(), &[3, 5]);
+    assert_eq!(y.shape(), &[3]);
+}
+
+#[test]
+fn tensor_dataset_preserves_per_sample_shape() {
+    // Image-shaped samples: everything after the leading dimension passes through.
+    let images = Tensor::new(vec![0.0; 4 * 3 * 8 * 8], &[4, 3, 8, 8]);
+    let labels = Tensor::new(vec![0.0, 1.0, 2.0, 3.0], &[4]);
+    let dataset = TensorDataset::new(images, labels);
+
+    let (x, y) = dataset.get_batch(&[1, 2]);
+    assert_eq!(x.shape(), &[2, 3, 8, 8]);
+    assert_eq!(y.to_vec(), vec![1.0, 2.0]);
+}
+
+#[test]
+fn tensor_dataset_gathers_the_requested_samples() {
+    let x = Tensor::new((0..12).map(|i| i as f32).collect(), &[4, 3]);
+    let y = Tensor::new(vec![10.0, 11.0, 12.0, 13.0], &[4]);
+    let dataset = TensorDataset::new(x, y);
+
+    let (bx, by) = dataset.get_batch(&[3, 0]);
+    assert_eq!(bx.to_vec(), vec![9.0, 10.0, 11.0, 0.0, 1.0, 2.0]);
+    assert_eq!(by.to_vec(), vec![13.0, 10.0]);
+}
+
+#[test]
+#[should_panic(expected = "but")]
+fn tensor_dataset_rejects_mismatched_sample_counts() {
+    let x = Tensor::new(vec![0.0; 6], &[3, 2]);
+    let y = Tensor::new(vec![0.0; 2], &[2]);
+    let _ = TensorDataset::new(x, y);
+}
+
+#[test]
+fn dataloader_covers_every_sample_exactly_once() {
+    // 10 samples in batches of 4 -> 4 + 4 + 2.
+    let mut loader = DataLoader::new(synthetic(10, 3), 4, false);
+    assert_eq!(loader.num_batches(), 3);
+
+    let sizes: Vec<usize> = loader.by_ref().map(|(x, _)| x.shape()[0]).collect();
+    assert_eq!(sizes, vec![4, 4, 2]);
+
+    // And the same total after a reset.
+    loader.reset();
+    let total: usize = loader.map(|(x, _)| x.shape()[0]).sum();
+    assert_eq!(total, 10);
+}
+
+#[test]
+fn shuffling_reorders_without_losing_samples() {
+    // Distinct first features let us identify each sample after shuffling.
+    let dataset = TensorDataset::new(
+        Tensor::new((0..8).map(|i| i as f32).collect(), &[8, 1]),
+        Tensor::new(vec![0.0; 8], &[8]),
+    );
+    let mut loader = DataLoader::new(dataset, 8, true);
+
+    let seen: HashSet<u32> = loader
+        .by_ref()
+        .flat_map(|(x, _)| x.to_vec())
+        .map(|v| v as u32)
+        .collect();
+    assert_eq!(seen, (0..8).collect::<HashSet<u32>>());
+}
+
+#[test]
+#[should_panic(expected = "batch_size must be non-zero")]
+fn dataloader_rejects_a_zero_batch_size() {
+    let _ = DataLoader::new(synthetic(4, 2), 0, false);
+}
+
+/// A user-defined dataset needs nothing but the trait — no crate changes.
+struct Countdown {
+    samples: usize,
+}
+
+impl Dataset for Countdown {
+    fn len(&self) -> usize {
+        self.samples
+    }
+
+    fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor) {
+        let x: Vec<f32> = indices.iter().map(|&i| i as f32).collect();
+        let y: Vec<f32> = indices.iter().map(|&i| (i % 2) as f32).collect();
+        (
+            Tensor::new(x, &[indices.len(), 1]),
+            Tensor::new(y, &[indices.len()]),
+        )
+    }
+}
+
+#[test]
+fn a_custom_dataset_works_with_the_loader() {
+    let mut loader = DataLoader::new(Countdown { samples: 5 }, 2, false);
+    assert_eq!(loader.num_batches(), 3);
+
+    let (x, y) = loader.next().unwrap();
+    assert_eq!(x.to_vec(), vec![0.0, 1.0]);
+    assert_eq!(y.to_vec(), vec![0.0, 1.0]);
+}
+
+/// The point of the whole change: `Trainer` trains on data that is not MNIST.
+#[test]
+fn trainer_learns_a_non_mnist_dataset() {
+    let features = 6;
+    let model = Sequential::new(vec![
+        Box::new(Linear::new(features, 16, true)),
+        Box::new(ReLU),
+        Box::new(Linear::new(16, 2, true)),
+    ]);
+    let optimizer = Adam::new(model.parameters(), 0.01, None, None, None);
+    let mut trainer = Trainer::new(Box::new(model), optimizer, None);
+
+    let mut train = DataLoader::new(synthetic(256, features), 32, true);
+
+    let (first_loss, _) = trainer.train_epoch(&mut train);
+    for _ in 0..4 {
+        trainer.train_epoch(&mut train);
+    }
+    let (last_loss, last_acc) = trainer.train_epoch(&mut train);
+
+    assert!(
+        last_loss < first_loss,
+        "loss did not fall: {first_loss} -> {last_loss}"
+    );
+    assert!(
+        last_acc > 0.9,
+        "separable problem should be learned, got {last_acc}"
+    );
+}
+
+/// `fit` is the headline entry point, so it has to be dataset-generic too.
+#[test]
+fn fit_runs_end_to_end_on_a_custom_dataset() {
+    let features = 4;
+    let model = Sequential::new(vec![
+        Box::new(Linear::new(features, 8, true)),
+        Box::new(ReLU),
+        Box::new(Linear::new(8, 2, true)),
+    ]);
+    let optimizer = Adam::new(model.parameters(), 0.01, None, None, None);
+    let mut trainer = Trainer::new(Box::new(model), optimizer, None).with_early_stop(None);
+
+    let mut train = DataLoader::new(synthetic(128, features), 16, true);
+    let mut val = DataLoader::new(synthetic(64, features), 16, false);
+
+    trainer.fit(&mut train, &mut val, 3, false);
+
+    assert_eq!(trainer.metrics.train_loss.len(), 3);
+    assert!(
+        trainer.metrics.val_acc.last().copied().unwrap_or(0.0) > 0.9,
+        "validation accuracy did not reach 90%: {:?}",
+        trainer.metrics.val_acc
+    );
+}


### PR DESCRIPTION
The single biggest blocker to anyone using taper: `DataLoader` held a concrete
`MNISTDataset`, `get_batch` hardcoded `784` in five places, and
`Trainer::train_epoch`/`evaluate`/`fit` all took that one type. **The headline
training API worked on exactly one dataset.** Bringing your own data meant
abandoning `Trainer` and writing the loop yourself.

Training is now expressed against a `Dataset` trait:

```rust
pub trait Dataset {
    fn len(&self) -> usize;
    fn get_batch(&self, indices: &[usize]) -> (Tensor, Tensor);
}
```

Batching is a gather over indices rather than one sample at a time, so a whole
batch can still be assembled in a single pass — MNIST keeps its parallel copy.

- `DataLoader<D: Dataset>` is generic; `Trainer`'s methods take any implementation.
- `TensorDataset` covers in-memory data. Everything after the leading sample
  dimension is your feature shape, so `[N, features]` and `[N, C, H, W]` both work.
- `data::mnist::DataLoader` is re-exported, so existing code keeps compiling.

MNIST is unchanged from the outside — `784` now appears only in IDX parsing,
where it genuinely is part of the file format — and still trains to 97.8%.

Tests cover arbitrary feature widths, 4D samples, batch coverage and short final
batches, shuffling, a user-defined `Dataset`, and `Trainer` learning a synthetic
6-feature problem end to end through `fit`.

140 tests, clippy clean.