### PR TITLE
Add LayerNorm and BatchNorm2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight neural network library in Rust with automatic differentiation.
 ## Features
 - Dynamic computational graph with tape-based autograd
 - SIMD-optimized tensor operations (AVX/SSE/NEON, with a scalar fallback)
-- Neural network layers: Linear, ReLU, Sigmoid, Conv2D, MaxPool2D, AvgPool2D, Dropout, Flatten
+- Neural network layers: Linear, Conv2D, MaxPool2D, AvgPool2D, LayerNorm, BatchNorm2d, Dropout, Flatten, ReLU, Sigmoid
 - Optimizers: SGD (with momentum), Adam, AdamW, and learning rate scheduling
 - Loss functions: MSE, Cross-entropy, BCE
 - Post-Training Quantization (PTQ) and Quantization-Aware Training (QAT)
@@ -75,6 +75,31 @@ Batching is a gather over indices rather than one sample at a time, so a whole
 batch can be assembled in a single pass.
 
 [`Dataset`]: https://docs.rs/taper/latest/taper/data/trait.Dataset.html
+
+### Normalization
+
+`LayerNorm` normalizes the trailing dimensions of each sample, so it is
+independent of batch composition. `BatchNorm2d` normalizes each channel across
+the batch, so it tracks running statistics during training and uses those at
+evaluation:
+
+```rust
+use taper::norm::{BatchNorm2d, LayerNorm};
+
+let model = Sequential::new(vec![
+    Box::new(Conv2dReLU::conv3x3(1, 32, 1, 1)),
+    Box::new(BatchNorm2d::new(32)),
+    // ...
+]);
+
+model.set_training(false); // BatchNorm switches to its running statistics
+```
+
+Running statistics are **buffers**, not parameters: they are saved and loaded
+with the model but never handed to an optimizer, which would apply momentum and
+weight decay to what are observations rather than weights. Normalizing with
+batch statistics at inference would make a prediction depend on whatever else
+shared its batch, and would divide by ~`eps` for a batch of one.
 
 ### Inference
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod data;
 pub mod gemm;
 pub mod loss;
 pub mod nn;
+pub mod norm;
 pub mod ops;
 pub mod optim;
 pub mod quantization;

--- a/src/nn.rs
+++ b/src/nn.rs
@@ -11,6 +11,17 @@ pub trait Module {
     fn forward(&self, input: &Tensor) -> Tensor;
     fn parameters(&self) -> Vec<Tensor>;
 
+    /// Non-learnable state that must persist across save/load but must never
+    /// be handed to an optimizer — BatchNorm's running statistics, for example.
+    ///
+    /// These are observations, not weights: applying momentum and weight decay
+    /// to them would make them drift instead of tracking the data, while
+    /// leaving them out of checkpoints entirely would make a reloaded model
+    /// normalize with reset statistics.
+    fn buffers(&self) -> Vec<Tensor> {
+        Vec::new()
+    }
+
     /// Switch this module (and any children) between training and inference
     /// behaviour. Layers whose forward pass is mode-independent can ignore it.
     ///
@@ -160,6 +171,10 @@ impl Sequential {
 impl Module for Sequential {
     fn forward(&self, input: &Tensor) -> Tensor {
         self.layers.iter().fold(input.clone(), |x, l| l.forward(&x))
+    }
+
+    fn buffers(&self) -> Vec<Tensor> {
+        self.layers.iter().flat_map(|l| l.buffers()).collect()
     }
 
     fn set_training(&mut self, training: bool) {

--- a/src/norm.rs
+++ b/src/norm.rs
@@ -1,0 +1,435 @@
+//! Normalization layers.
+//!
+//! Both layers standardize a group of activations to zero mean and unit
+//! variance, then apply a learnable per-feature scale and shift. They differ in
+//! what they group over:
+//!
+//! - [`LayerNorm`] groups the trailing dimensions of a single sample, so it is
+//!   independent of batch composition and behaves identically in training and
+//!   evaluation.
+//! - [`BatchNorm2d`] groups each channel across the batch and spatial extent,
+//!   which means it *does* depend on batch composition — so it tracks running
+//!   statistics during training and uses those at evaluation time.
+//!
+//! The forward and backward passes are fused rather than composed from
+//! primitive ops: the normalization statistics depend on the input, so the
+//! derivative does not factor into the elementwise ops the crate already has.
+//! Both backwards are checked against finite differences in `tests/norm.rs`.
+
+use crate::tape::Tape;
+use crate::{Tensor, nn::Module, ops};
+
+/// The shared backward for a normalized group.
+///
+/// With `m` elements in a group, `xhat` the standardized values and `dxhat` the
+/// incoming gradient already scaled by gamma:
+///
+/// ```text
+/// dx = inv_std / m * (m * dxhat - Σ dxhat - xhat * Σ (dxhat * xhat))
+/// ```
+///
+/// The two sums are what makes this irreducible to elementwise ops: every input
+/// in the group influences every output through the mean and variance.
+#[inline]
+fn group_backward(dxhat: &[f32], xhat: &[f32], inv_std: f32, out: &mut [f32]) {
+    let m = dxhat.len() as f32;
+    let sum_dxhat: f32 = dxhat.iter().sum();
+    let sum_dxhat_xhat: f32 = dxhat.iter().zip(xhat).map(|(d, h)| d * h).sum();
+
+    for ((o, &d), &h) in out.iter_mut().zip(dxhat).zip(xhat) {
+        *o = inv_std / m * (m * d - sum_dxhat - h * sum_dxhat_xhat);
+    }
+}
+
+/// Mean and variance of a slice, in one pass over deviations for stability.
+#[inline]
+fn mean_var(values: &[f32]) -> (f32, f32) {
+    let m = values.len() as f32;
+    let mean = values.iter().sum::<f32>() / m;
+    let var = values.iter().map(|v| (v - mean) * (v - mean)).sum::<f32>() / m;
+    (mean, var)
+}
+
+/// Normalizes over the trailing dimensions of each sample.
+///
+/// Given an input whose trailing dimensions have `normalized_size` elements in
+/// total, each such block is standardized independently, then scaled and
+/// shifted by learnable per-element parameters.
+#[derive(Debug)]
+pub struct LayerNorm {
+    /// Learnable scale, shape `[normalized_size]`.
+    pub gamma: Tensor,
+    /// Learnable shift, shape `[normalized_size]`.
+    pub beta: Option<Tensor>,
+    normalized_size: usize,
+    eps: f32,
+}
+
+impl LayerNorm {
+    /// `normalized_shape` gives the trailing dimensions to normalize over —
+    /// `&[features]` for `[batch, features]`, `&[d_model]` for a transformer's
+    /// `[batch, seq, d_model]`.
+    pub fn new(normalized_shape: &[usize], affine: bool, eps: Option<f32>) -> Self {
+        assert!(
+            !normalized_shape.is_empty(),
+            "LayerNorm: normalized_shape must not be empty"
+        );
+        let normalized_size: usize = normalized_shape.iter().product();
+        assert!(
+            normalized_size > 0,
+            "LayerNorm: normalized_shape {normalized_shape:?} has no elements"
+        );
+
+        LayerNorm {
+            gamma: Tensor::new(vec![1.0; normalized_size], &[normalized_size]).requires_grad(),
+            beta: affine.then(|| {
+                Tensor::new(vec![0.0; normalized_size], &[normalized_size]).requires_grad()
+            }),
+            normalized_size,
+            eps: eps.unwrap_or(1e-5),
+        }
+    }
+
+    /// Convenience for the common `[.., features]` case.
+    pub fn with_features(features: usize) -> Self {
+        Self::new(&[features], true, None)
+    }
+}
+
+impl Module for LayerNorm {
+    fn forward(&self, input: &Tensor) -> Tensor {
+        let size = self.normalized_size;
+        assert!(
+            input.numel().is_multiple_of(size),
+            "LayerNorm: input of {} elements is not divisible by normalized size {size}",
+            input.numel()
+        );
+
+        let values = input.to_vec();
+        let rows = values.len() / size;
+        let gamma = self.gamma.to_vec();
+        let beta = self.beta.as_ref().map(|b| b.to_vec());
+
+        // Keep the standardized values: the backward needs them, and
+        // recomputing would mean a second pass over the input.
+        let mut xhat = vec![0.0f32; values.len()];
+        let mut inv_stds = Vec::with_capacity(rows);
+        let mut out = vec![0.0f32; values.len()];
+
+        for r in 0..rows {
+            let span = r * size..(r + 1) * size;
+            let (mean, var) = mean_var(&values[span.clone()]);
+            let inv_std = 1.0 / (var + self.eps).sqrt();
+            inv_stds.push(inv_std);
+
+            for i in 0..size {
+                let h = (values[span.start + i] - mean) * inv_std;
+                xhat[span.start + i] = h;
+                out[span.start + i] = h * gamma[i] + beta.as_ref().map_or(0.0, |b| b[i]);
+            }
+        }
+
+        let mut output = Tensor::new(out, input.shape());
+
+        let track = input.requires_grad
+            || self.gamma.requires_grad
+            || self.beta.as_ref().is_some_and(|b| b.requires_grad);
+        if track {
+            output.requires_grad = true;
+            let x = input.clone();
+            let gamma_t = self.gamma.clone();
+            let beta_t = self.beta.clone();
+            let out_t = output.clone();
+
+            Tape::push_unary_op(input, &output, move || {
+                let Some(gout) = out_t
+                    .grad
+                    .read()
+                    .expect("grad RwLock poisoned")
+                    .as_ref()
+                    .cloned()
+                else {
+                    return;
+                };
+
+                let mut dgamma = vec![0.0f32; size];
+                let mut dbeta = vec![0.0f32; size];
+                let mut dx = vec![0.0f32; gout.len()];
+                let mut dxhat = vec![0.0f32; size];
+
+                for (r, &inv_std) in inv_stds.iter().enumerate() {
+                    let base = r * size;
+                    for i in 0..size {
+                        let g = gout[base + i];
+                        dgamma[i] += g * xhat[base + i];
+                        dbeta[i] += g;
+                        dxhat[i] = g * gamma[i];
+                    }
+                    group_backward(
+                        &dxhat,
+                        &xhat[base..base + size],
+                        inv_std,
+                        &mut dx[base..base + size],
+                    );
+                }
+
+                if x.requires_grad {
+                    ops::accumulate_grad(&x, &dx);
+                }
+                if gamma_t.requires_grad {
+                    ops::accumulate_grad(&gamma_t, &dgamma);
+                }
+                if let Some(b) = &beta_t
+                    && b.requires_grad
+                {
+                    ops::accumulate_grad(b, &dbeta);
+                }
+            });
+        }
+
+        output
+    }
+
+    fn parameters(&self) -> Vec<Tensor> {
+        let mut p = vec![self.gamma.clone()];
+        if let Some(b) = &self.beta {
+            p.push(b.clone());
+        }
+        p
+    }
+}
+
+/// Per-channel normalization over a 4D batch, `[N, C, H, W]`.
+///
+/// During training each channel is standardized using that batch's statistics,
+/// and running estimates are updated. At evaluation the running estimates are
+/// used instead, so a prediction depends only on its own input — normalizing
+/// with batch statistics at inference would make results depend on whatever
+/// else shared the batch, and would divide by ~`eps` for a batch of one.
+#[derive(Debug)]
+pub struct BatchNorm2d {
+    /// Learnable scale, shape `[channels]`.
+    pub gamma: Tensor,
+    /// Learnable shift, shape `[channels]`.
+    pub beta: Tensor,
+    /// Running mean, shape `[channels]`. Not learnable: updated by observation,
+    /// never by the optimizer.
+    running_mean: Tensor,
+    /// Running variance, shape `[channels]`.
+    running_var: Tensor,
+    channels: usize,
+    momentum: f32,
+    eps: f32,
+    training: bool,
+}
+
+impl BatchNorm2d {
+    pub fn new(channels: usize) -> Self {
+        Self::with_config(channels, 0.1, 1e-5)
+    }
+
+    /// `momentum` weights each batch's contribution to the running estimates.
+    pub fn with_config(channels: usize, momentum: f32, eps: f32) -> Self {
+        assert!(channels > 0, "BatchNorm2d: channels must be non-zero");
+        assert!(
+            (0.0..=1.0).contains(&momentum),
+            "BatchNorm2d: momentum must be in [0, 1], got {momentum}"
+        );
+
+        BatchNorm2d {
+            gamma: Tensor::new(vec![1.0; channels], &[channels]).requires_grad(),
+            beta: Tensor::new(vec![0.0; channels], &[channels]).requires_grad(),
+            // Start as a standard normal, so an untrained layer in eval mode is
+            // a no-op rather than a division by zero.
+            running_mean: Tensor::new(vec![0.0; channels], &[channels]),
+            running_var: Tensor::new(vec![1.0; channels], &[channels]),
+            channels,
+            momentum,
+            eps,
+            training: true,
+        }
+    }
+
+    pub fn is_training(&self) -> bool {
+        self.training
+    }
+
+    /// The running mean tracked so far.
+    pub fn running_mean(&self) -> &Tensor {
+        &self.running_mean
+    }
+
+    /// The running variance tracked so far.
+    pub fn running_var(&self) -> &Tensor {
+        &self.running_var
+    }
+}
+
+impl Module for BatchNorm2d {
+    fn forward(&self, input: &Tensor) -> Tensor {
+        assert_eq!(
+            input.shape().len(),
+            4,
+            "BatchNorm2d expects [N, C, H, W], got {:?}",
+            input.shape()
+        );
+        let (n, c, h, w) = (
+            input.shape()[0],
+            input.shape()[1],
+            input.shape()[2],
+            input.shape()[3],
+        );
+        assert_eq!(
+            c, self.channels,
+            "BatchNorm2d: layer has {} channels but input has {c}",
+            self.channels
+        );
+
+        let values = input.to_vec();
+        let gamma = self.gamma.to_vec();
+        let beta = self.beta.to_vec();
+        let spatial = h * w;
+        let group = n * spatial; // elements per channel
+
+        if self.training {
+            assert!(
+                group > 1,
+                "BatchNorm2d: training needs more than one element per channel, \
+                 got batch {n} of {h}x{w}"
+            );
+        }
+
+        // Positions belonging to channel `ch`, in NCHW order.
+        let channel_indices = |ch: usize| {
+            (0..n).flat_map(move |b| {
+                let base = b * c * spatial + ch * spatial;
+                base..base + spatial
+            })
+        };
+
+        let mut xhat = vec![0.0f32; values.len()];
+        let mut out = vec![0.0f32; values.len()];
+        let mut inv_stds = Vec::with_capacity(c);
+
+        for ch in 0..c {
+            let (mean, var) = if self.training {
+                let slice: Vec<f32> = channel_indices(ch).map(|i| values[i]).collect();
+                let (mean, var) = mean_var(&slice);
+
+                // Bessel-corrected variance goes into the running estimate, so
+                // it is an unbiased estimator of the population variance, while
+                // the biased one is used to normalize this batch.
+                let unbiased = var * group as f32 / (group as f32 - 1.0);
+                let mut rm = self.running_mean.data_mut();
+                let mut rv = self.running_var.data_mut();
+                rm[ch] = (1.0 - self.momentum) * rm[ch] + self.momentum * mean;
+                rv[ch] = (1.0 - self.momentum) * rv[ch] + self.momentum * unbiased;
+
+                (mean, var)
+            } else {
+                (
+                    self.running_mean.to_vec()[ch],
+                    self.running_var.to_vec()[ch],
+                )
+            };
+
+            let inv_std = 1.0 / (var + self.eps).sqrt();
+            inv_stds.push(inv_std);
+
+            for i in channel_indices(ch) {
+                let hval = (values[i] - mean) * inv_std;
+                xhat[i] = hval;
+                out[i] = hval * gamma[ch] + beta[ch];
+            }
+        }
+
+        let mut output = Tensor::new(out, input.shape());
+
+        let track = input.requires_grad || self.gamma.requires_grad || self.beta.requires_grad;
+        if track {
+            output.requires_grad = true;
+            let x = input.clone();
+            let gamma_t = self.gamma.clone();
+            let beta_t = self.beta.clone();
+            let out_t = output.clone();
+            let training = self.training;
+
+            Tape::push_unary_op(input, &output, move || {
+                let Some(gout) = out_t
+                    .grad
+                    .read()
+                    .expect("grad RwLock poisoned")
+                    .as_ref()
+                    .cloned()
+                else {
+                    return;
+                };
+
+                let mut dgamma = vec![0.0f32; c];
+                let mut dbeta = vec![0.0f32; c];
+                let mut dx = vec![0.0f32; gout.len()];
+
+                for ch in 0..c {
+                    let positions: Vec<usize> = (0..n)
+                        .flat_map(|b| {
+                            let base = b * c * spatial + ch * spatial;
+                            base..base + spatial
+                        })
+                        .collect();
+
+                    let mut dxhat = Vec::with_capacity(positions.len());
+                    let mut hats = Vec::with_capacity(positions.len());
+                    for &i in &positions {
+                        dgamma[ch] += gout[i] * xhat[i];
+                        dbeta[ch] += gout[i];
+                        dxhat.push(gout[i] * gamma[ch]);
+                        hats.push(xhat[i]);
+                    }
+
+                    if training {
+                        // The batch statistics depend on x, so every element in
+                        // the channel contributes to every other's gradient.
+                        let mut grads = vec![0.0f32; positions.len()];
+                        group_backward(&dxhat, &hats, inv_stds[ch], &mut grads);
+                        for (&i, g) in positions.iter().zip(grads) {
+                            dx[i] = g;
+                        }
+                    } else {
+                        // Running statistics are constants here, so the
+                        // derivative is a plain scale.
+                        for (&i, d) in positions.iter().zip(dxhat) {
+                            dx[i] = d * inv_stds[ch];
+                        }
+                    }
+                }
+
+                if x.requires_grad {
+                    ops::accumulate_grad(&x, &dx);
+                }
+                if gamma_t.requires_grad {
+                    ops::accumulate_grad(&gamma_t, &dgamma);
+                }
+                if beta_t.requires_grad {
+                    ops::accumulate_grad(&beta_t, &dbeta);
+                }
+            });
+        }
+
+        output
+    }
+
+    fn set_training(&mut self, training: bool) {
+        self.training = training;
+    }
+
+    fn parameters(&self) -> Vec<Tensor> {
+        // Running statistics are deliberately absent: handing them to an
+        // optimizer would have it apply momentum and weight decay to what are
+        // observations, not weights. They are exposed as buffers instead.
+        vec![self.gamma.clone(), self.beta.clone()]
+    }
+
+    fn buffers(&self) -> Vec<Tensor> {
+        vec![self.running_mean.clone(), self.running_var.clone()]
+    }
+}

--- a/src/safetensors.rs
+++ b/src/safetensors.rs
@@ -386,49 +386,71 @@ pub fn load_ordered<P: AsRef<Path>>(path: P) -> Result<Vec<(String, Tensor)>, Er
     Ok(out)
 }
 
-/// Save a module's parameters, named by their position in `parameters()`.
+/// Save a module's parameters and buffers, named by their position.
 ///
-/// The trait exposes no names, so these are positional (`param.0`, `param.1`,
+/// The trait exposes no names, so these are positional (`param.0`, `buffer.0`,
 /// …) and only reload into a module with the same structure. Use [`save`]
 /// directly when you have real names to attach.
+///
+/// Buffers are included because a layer's non-learnable state is part of what
+/// makes it reproduce its results — a BatchNorm reloaded without its running
+/// statistics normalizes with reset ones and infers wrongly.
 pub fn save_module<P: AsRef<Path>>(module: &dyn Module, path: P) -> Result<(), Error> {
     let params = module.parameters();
-    let names: Vec<String> = (0..params.len()).map(|i| format!("param.{i}")).collect();
+    let buffers = module.buffers();
+
+    let names: Vec<String> = (0..params.len())
+        .map(|i| format!("param.{i}"))
+        .chain((0..buffers.len()).map(|i| format!("buffer.{i}")))
+        .collect();
     let entries: Vec<(&str, &Tensor)> = names
         .iter()
         .map(String::as_str)
-        .zip(params.iter())
+        .zip(params.iter().chain(buffers.iter()))
         .collect();
     save(&entries, path)
 }
 
-/// Load parameters written by [`save_module`] back into a module.
+/// Load parameters and buffers written by [`save_module`] back into a module.
 pub fn load_module<P: AsRef<Path>>(module: &dyn Module, path: P) -> Result<(), Error> {
     let loaded = load(path)?;
     let params = module.parameters();
+    let buffers = module.buffers();
 
-    if loaded.len() != params.len() {
+    let expected = params.len() + buffers.len();
+    if loaded.len() != expected {
         return Err(malformed(format!(
-            "file holds {} tensors but the module has {} parameters",
+            "file holds {} tensors but the module has {} parameters and {} buffers",
             loaded.len(),
-            params.len()
+            params.len(),
+            buffers.len()
         )));
     }
 
-    for (i, param) in params.iter().enumerate() {
-        let name = format!("param.{i}");
+    let targets = params
+        .iter()
+        .enumerate()
+        .map(|(i, t)| (format!("param.{i}"), t))
+        .chain(
+            buffers
+                .iter()
+                .enumerate()
+                .map(|(i, t)| (format!("buffer.{i}"), t)),
+        );
+
+    for (name, target) in targets {
         let source = loaded
             .get(&name)
             .ok_or_else(|| malformed(format!("file has no tensor named {name:?}")))?;
 
-        if source.shape() != param.shape() {
+        if source.shape() != target.shape() {
             return Err(malformed(format!(
                 "{name} has shape {:?} but the module expects {:?}",
                 source.shape(),
-                param.shape()
+                target.shape()
             )));
         }
-        param.data_mut().copy_from_slice(&source.to_vec());
+        target.data_mut().copy_from_slice(&source.to_vec());
     }
     Ok(())
 }

--- a/tests/norm.rs
+++ b/tests/norm.rs
@@ -1,0 +1,404 @@
+//! Normalization layers.
+//!
+//! Both backwards are hand-derived rather than composed from primitive ops, so
+//! each is checked against finite differences — the same discipline that caught
+//! conv2d having no gradient path at all.
+
+use taper::nn::Module;
+use taper::norm::{BatchNorm2d, LayerNorm};
+use taper::{Tape, Tensor};
+
+/// Central-difference gradient of `objective` at `values`.
+fn numeric_gradient(values: &[f32], objective: impl Fn(&[f32]) -> f32) -> Vec<f32> {
+    let eps = 1e-2;
+    (0..values.len())
+        .map(|i| {
+            let mut plus = values.to_vec();
+            plus[i] += eps;
+            let mut minus = values.to_vec();
+            minus[i] -= eps;
+            (objective(&plus) - objective(&minus)) / (2.0 * eps)
+        })
+        .collect()
+}
+
+/// Deterministic, non-degenerate values.
+fn sample(n: usize) -> Vec<f32> {
+    (0..n)
+        .map(|i| ((i * 37 % 23) as f32 - 11.0) * 0.13)
+        .collect()
+}
+
+// --- LayerNorm ---
+
+#[test]
+fn layer_norm_standardizes_each_row() {
+    let x = Tensor::new(vec![1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0], &[2, 4]);
+    let ln = LayerNorm::new(&[4], true, None);
+    let y = ln.forward(&x).to_vec();
+
+    // With gamma=1, beta=0 each row has zero mean and unit variance.
+    for row in y.chunks(4) {
+        let mean = row.iter().sum::<f32>() / 4.0;
+        let var = row.iter().map(|v| (v - mean) * (v - mean)).sum::<f32>() / 4.0;
+        assert!(mean.abs() < 1e-5, "row mean {mean} should be ~0");
+        assert!((var - 1.0).abs() < 1e-3, "row variance {var} should be ~1");
+    }
+
+    // Both rows are the same pattern at different scale, so they standardize
+    // to the same values — that is the point of normalizing per sample.
+    for i in 0..4 {
+        assert!((y[i] - y[4 + i]).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn layer_norm_is_independent_of_the_other_rows() {
+    let ln = LayerNorm::new(&[3], true, None);
+    let alone = ln
+        .forward(&Tensor::new(vec![1.0, 2.0, 3.0], &[1, 3]))
+        .to_vec();
+    let batched = ln
+        .forward(&Tensor::new(
+            vec![1.0, 2.0, 3.0, 100.0, -50.0, 7.0],
+            &[2, 3],
+        ))
+        .to_vec();
+
+    assert_eq!(alone.len(), 3);
+    for i in 0..3 {
+        assert!((alone[i] - batched[i]).abs() < 1e-5);
+    }
+}
+
+#[test]
+fn layer_norm_applies_its_affine_parameters() {
+    let ln = LayerNorm::new(&[2], true, None);
+    ln.gamma.data_mut().copy_from_slice(&[2.0, 3.0]);
+    ln.beta
+        .as_ref()
+        .unwrap()
+        .data_mut()
+        .copy_from_slice(&[1.0, -1.0]);
+
+    let y = ln.forward(&Tensor::new(vec![0.0, 1.0], &[1, 2])).to_vec();
+    // Standardized row is [-1, 1]; scaled and shifted gives [-1, 2].
+    assert!((y[0] - (-1.0)).abs() < 1e-3, "got {y:?}");
+    assert!((y[1] - 2.0).abs() < 1e-3, "got {y:?}");
+}
+
+#[test]
+fn layer_norm_gradients_match_finite_differences() {
+    let shape = [3usize, 4];
+    let x = sample(12);
+    let coefficients = sample(12).iter().map(|v| v + 0.7).collect::<Vec<_>>();
+
+    let ln = LayerNorm::new(&[4], true, None);
+    ln.gamma.data_mut().copy_from_slice(&[1.3, -0.7, 0.5, 2.0]);
+    ln.beta
+        .as_ref()
+        .unwrap()
+        .data_mut()
+        .copy_from_slice(&[0.1, 0.2, -0.3, 0.4]);
+
+    // Scalar objective so a single backward gives every partial derivative.
+    let objective = |values: &[f32]| -> f32 {
+        let out = ln.forward(&Tensor::new(values.to_vec(), &shape));
+        out.to_vec()
+            .iter()
+            .zip(&coefficients)
+            .map(|(o, c)| o * c)
+            .sum()
+    };
+
+    Tape::reset();
+    let xt = Tensor::new(x.clone(), &shape).requires_grad();
+    let out = ln.forward(&xt);
+    let weighted = &out * &Tensor::new(coefficients.clone(), &shape);
+    weighted.sum(None, false).backward();
+
+    let analytic = xt.grad_ref().expect("no input gradient");
+    let numeric = numeric_gradient(&x, objective);
+    for i in 0..x.len() {
+        assert!(
+            (analytic[i] - numeric[i]).abs() < 2e-2,
+            "input grad {i}: analytic {} vs numeric {}",
+            analytic[i],
+            numeric[i]
+        );
+    }
+
+    // And the affine parameters.
+    let gamma_now = ln.gamma.to_vec();
+    let gamma_numeric = numeric_gradient(&gamma_now, |g| {
+        ln.gamma.data_mut().copy_from_slice(g);
+        let v = objective(&x);
+        ln.gamma.data_mut().copy_from_slice(&gamma_now);
+        v
+    });
+    let gamma_analytic = ln.gamma.grad_ref().expect("no gamma gradient");
+    for i in 0..gamma_now.len() {
+        assert!(
+            (gamma_analytic[i] - gamma_numeric[i]).abs() < 2e-2,
+            "gamma grad {i}: analytic {} vs numeric {}",
+            gamma_analytic[i],
+            gamma_numeric[i]
+        );
+    }
+}
+
+// --- BatchNorm2d ---
+
+#[test]
+fn batch_norm_standardizes_each_channel() {
+    let (n, c, h, w) = (2usize, 2, 2, 2);
+    let x = Tensor::new(sample(n * c * h * w), &[n, c, h, w]);
+    let bn = BatchNorm2d::new(c);
+    let y = bn.forward(&x).to_vec();
+
+    let spatial = h * w;
+    for ch in 0..c {
+        let vals: Vec<f32> = (0..n)
+            .flat_map(|b| {
+                let base = b * c * spatial + ch * spatial;
+                (base..base + spatial).map(|i| y[i])
+            })
+            .collect();
+        let mean = vals.iter().sum::<f32>() / vals.len() as f32;
+        let var = vals.iter().map(|v| (v - mean) * (v - mean)).sum::<f32>() / vals.len() as f32;
+        assert!(mean.abs() < 1e-4, "channel {ch} mean {mean}");
+        assert!((var - 1.0).abs() < 1e-2, "channel {ch} variance {var}");
+    }
+}
+
+/// The property PR-style BatchNorm without running statistics gets wrong: at
+/// inference a prediction must not depend on what else shares the batch.
+#[test]
+fn eval_mode_predictions_do_not_depend_on_the_batch() {
+    let (c, h, w) = (2usize, 2, 2);
+    let mut bn = BatchNorm2d::new(c);
+
+    // Train briefly so the running statistics are populated.
+    let train_x = Tensor::new(sample(4 * c * h * w), &[4, c, h, w]);
+    for _ in 0..5 {
+        bn.forward(&train_x);
+    }
+    bn.set_training(false);
+
+    let one = sample(c * h * w);
+    let alone = bn
+        .forward(&Tensor::new(one.clone(), &[1, c, h, w]))
+        .to_vec();
+
+    // The same sample, now sharing a batch with wildly different data.
+    let mut together = one.clone();
+    together.extend(sample(c * h * w).iter().map(|v| v * 50.0 + 30.0));
+    let batched = bn.forward(&Tensor::new(together, &[2, c, h, w])).to_vec();
+
+    for i in 0..one.len() {
+        assert!(
+            (alone[i] - batched[i]).abs() < 1e-5,
+            "element {i} changed with batch composition: {} vs {}",
+            alone[i],
+            batched[i]
+        );
+    }
+}
+
+#[test]
+fn eval_mode_works_with_a_batch_of_one() {
+    let (c, h, w) = (2usize, 2, 2);
+    let mut bn = BatchNorm2d::new(c);
+    bn.set_training(false);
+
+    // Batch statistics would give zero variance here and divide by ~eps.
+    let y = bn.forward(&Tensor::new(sample(c * h * w), &[1, c, h, w]));
+    assert!(
+        y.to_vec().iter().all(|v| v.is_finite()),
+        "batch-of-one inference produced non-finite values: {:?}",
+        y.to_vec()
+    );
+}
+
+#[test]
+fn running_statistics_track_the_data_and_are_not_parameters() {
+    let (n, c, h, w) = (4usize, 2, 2, 2);
+    let bn = BatchNorm2d::new(c);
+
+    // Start at the standard-normal defaults.
+    assert_eq!(bn.running_mean().to_vec(), vec![0.0, 0.0]);
+    assert_eq!(bn.running_var().to_vec(), vec![1.0, 1.0]);
+
+    // Data with a large positive offset should drag the running mean up.
+    let shifted: Vec<f32> = sample(n * c * h * w).iter().map(|v| v + 10.0).collect();
+    let x = Tensor::new(shifted, &[n, c, h, w]);
+    for _ in 0..20 {
+        bn.forward(&x);
+    }
+    assert!(
+        bn.running_mean().to_vec().iter().all(|m| *m > 5.0),
+        "running mean did not track the data: {:?}",
+        bn.running_mean().to_vec()
+    );
+
+    // They must not be handed to an optimizer.
+    assert_eq!(
+        bn.parameters().len(),
+        2,
+        "only gamma and beta are learnable"
+    );
+    assert_eq!(
+        bn.buffers().len(),
+        2,
+        "running mean and variance are buffers"
+    );
+}
+
+#[test]
+fn batch_norm_gradients_match_finite_differences() {
+    let (n, c, h, w) = (3usize, 2, 2, 2);
+    let shape = [n, c, h, w];
+    let count = n * c * h * w;
+    let x = sample(count);
+    let coefficients: Vec<f32> = sample(count).iter().map(|v| v + 0.4).collect();
+
+    let bn = BatchNorm2d::new(c);
+    bn.gamma.data_mut().copy_from_slice(&[1.4, -0.6]);
+    bn.beta.data_mut().copy_from_slice(&[0.25, -0.1]);
+
+    let objective = |values: &[f32]| -> f32 {
+        let out = bn.forward(&Tensor::new(values.to_vec(), &shape));
+        out.to_vec()
+            .iter()
+            .zip(&coefficients)
+            .map(|(o, cf)| o * cf)
+            .sum()
+    };
+
+    Tape::reset();
+    let xt = Tensor::new(x.clone(), &shape).requires_grad();
+    let out = bn.forward(&xt);
+    let weighted = &out * &Tensor::new(coefficients.clone(), &shape);
+    weighted.sum(None, false).backward();
+
+    let analytic = xt.grad_ref().expect("no input gradient");
+    let numeric = numeric_gradient(&x, objective);
+    for i in 0..count {
+        assert!(
+            (analytic[i] - numeric[i]).abs() < 2e-2,
+            "input grad {i}: analytic {} vs numeric {}",
+            analytic[i],
+            numeric[i]
+        );
+    }
+
+    let gamma_now = bn.gamma.to_vec();
+    let gamma_numeric = numeric_gradient(&gamma_now, |g| {
+        bn.gamma.data_mut().copy_from_slice(g);
+        let v = objective(&x);
+        bn.gamma.data_mut().copy_from_slice(&gamma_now);
+        v
+    });
+    let gamma_analytic = bn.gamma.grad_ref().expect("no gamma gradient");
+    for i in 0..c {
+        assert!(
+            (gamma_analytic[i] - gamma_numeric[i]).abs() < 5e-2,
+            "gamma grad {i}: analytic {} vs numeric {}",
+            gamma_analytic[i],
+            gamma_numeric[i]
+        );
+    }
+}
+
+#[test]
+fn eval_mode_gradients_match_finite_differences() {
+    // With running statistics held constant the derivative is a plain scale,
+    // which is a different code path from the training one.
+    let (n, c, h, w) = (2usize, 2, 2, 2);
+    let shape = [n, c, h, w];
+    let count = n * c * h * w;
+    let x = sample(count);
+    let coefficients: Vec<f32> = sample(count).iter().map(|v| v + 0.9).collect();
+
+    let mut bn = BatchNorm2d::new(c);
+    bn.forward(&Tensor::new(sample(count), &shape)); // populate running stats
+    bn.set_training(false);
+
+    let objective = |values: &[f32]| -> f32 {
+        let out = bn.forward(&Tensor::new(values.to_vec(), &shape));
+        out.to_vec()
+            .iter()
+            .zip(&coefficients)
+            .map(|(o, cf)| o * cf)
+            .sum()
+    };
+
+    Tape::reset();
+    let xt = Tensor::new(x.clone(), &shape).requires_grad();
+    let out = bn.forward(&xt);
+    let weighted = &out * &Tensor::new(coefficients.clone(), &shape);
+    weighted.sum(None, false).backward();
+
+    let analytic = xt.grad_ref().unwrap();
+    let numeric = numeric_gradient(&x, objective);
+    for i in 0..count {
+        assert!(
+            (analytic[i] - numeric[i]).abs() < 2e-2,
+            "eval grad {i}: analytic {} vs numeric {}",
+            analytic[i],
+            numeric[i]
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "more than one element per channel")]
+fn training_rejects_a_degenerate_batch() {
+    let bn = BatchNorm2d::new(2);
+    // One element per channel: the variance is identically zero.
+    bn.forward(&Tensor::new(vec![1.0, 2.0], &[1, 2, 1, 1]));
+}
+
+/// A model reloaded without its running statistics normalizes with reset ones
+/// and infers differently, so buffers have to be part of the checkpoint.
+#[test]
+fn running_statistics_survive_a_checkpoint() {
+    use taper::nn::Sequential;
+    use taper::safetensors;
+
+    let (n, c, h, w) = (4usize, 2, 2, 2);
+    let mut path = std::env::temp_dir();
+    path.push(format!("taper_bn_{}.safetensors", std::process::id()));
+
+    let mut trained = Sequential::new(vec![Box::new(BatchNorm2d::new(c))]);
+    let data = Tensor::new(
+        sample(n * c * h * w).iter().map(|v| v + 4.0).collect(),
+        &[n, c, h, w],
+    );
+    for _ in 0..10 {
+        trained.forward(&data);
+    }
+    trained.set_training(false);
+
+    let probe = Tensor::new(sample(c * h * w), &[1, c, h, w]);
+    let expected = trained.forward(&probe).to_vec();
+
+    safetensors::save_module(&trained, &path).unwrap();
+
+    // A fresh layer starts from the standard-normal defaults, so it must differ
+    // before loading and agree exactly afterwards.
+    let mut restored = Sequential::new(vec![Box::new(BatchNorm2d::new(c))]);
+    restored.set_training(false);
+    assert_ne!(restored.forward(&probe).to_vec(), expected);
+
+    safetensors::load_module(&restored, &path).unwrap();
+    let after = restored.forward(&probe).to_vec();
+    for (a, e) in after.iter().zip(&expected) {
+        assert!(
+            (a - e).abs() < 1e-6,
+            "reloaded model infers differently: {a} vs {e}"
+        );
+    }
+
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
`LayerNorm` normalizes the trailing dimensions of each sample; `BatchNorm2d`
normalizes each channel across the batch and spatial extent.

Both are fused ops with hand-derived backwards. The normalization statistics
depend on the input, so every element in a group influences every other's
gradient and the derivative does not factor into the elementwise ops the crate
already has:

```text
dx = inv_std / m * (m * dxhat - Σ dxhat - xhat * Σ (dxhat * xhat))
```

Given that this repo's recurring bug is a hand-written backward that is quietly
wrong, **all four gradient paths are checked against finite differences** —
LayerNorm input and gamma, BatchNorm training input and gamma, plus the separate
eval-mode path where the statistics are constants.

### Running statistics

`BatchNorm2d` tracks running mean and variance during training and uses them in
eval mode. Without them, normalizing with batch statistics at inference makes a
prediction depend on whatever else shares its batch, and divides by ~`eps` for a
batch of one. Both properties are tested.

Those statistics are neither learnable nor disposable, so `Module` gains
`buffers()`: included in `safetensors::save_module`/`load_module`, excluded from
`parameters()`. Handing them to an optimizer would apply momentum and weight
decay to observations; leaving them out of checkpoints would make a reloaded
model normalize with reset statistics. There's a test asserting a reloaded model
infers identically.

### Note on #8

PR #8 also adds `src/norm.rs`, so these will conflict. Its `BatchNorm2d` has no
running statistics — only `gamma`, `beta`, `epsilon` — which is the
batch-dependent-inference case above. Happy to help reconcile them either way.

152 tests, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)