### PR TITLE
Fallible shape API, lock-poisoning recovery, and 0.2 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0]
+
+The tensor representation changed substantially in this release; code written
+against 0.1 that only used `Tensor`, `nn` and `optim` should still compile.
+
+### Fixed — correctness
+
+- **Convolution weights never received a gradient.** `im2col` and `transpose_4d`
+  rebuilt their outputs without a backward edge, severing the graph on both
+  sides of the matmul. A CNN's accuracy came entirely from its Linear head
+  learning on frozen random features. Measured on MNIST, the first conv layer's
+  weights moved by exactly zero before the fix.
+- **`Tensor::cat` declared only one of its inputs as a tape dependency.** Once
+  `backward` began traversing the dependency graph, every other input's subgraph
+  became unreachable, so a grouped convolution updated only its first group.
+- **Gradients were silently dropped for single-operation graphs.** `0` was used
+  both as a tape node id and as the "not an operation output" sentinel.
+- **`max(dim)` returned wrong values** for any non-final dimension of a rank-3+
+  tensor, with a clamp hiding the out-of-range indices.
+- **Asymmetric int8 quantization discarded half its range.** The zero point was
+  derived as `-min/scale`, correct only for an unsigned grid.
+- **conv2d paired weights with the wrong patches.** The weight was reshaped to
+  `[K, C_out]`, which reinterprets the buffer rather than transposing it.
+- **The 1×1 im2col path was a plain memcpy**, correct only when the spatial size
+  was 1; the general path underflowed `usize` on padded windows.
+- **SIMD kernels produced silent zeros** on targets without AVX/SSE2/NEON, and
+  indexed their second and third operands using the first's length.
+- Both cross-entropy backward passes recorded new operations *during* backward.
+- `SGD` accepted a `momentum` argument and discarded it.
+- Evaluation grew the tape without bound; `Dropout` inside a `Sequential` could
+  never be switched off.
+- Quantization-aware training was inert: the scale stayed at its placeholder
+  `1.0`, and module ids collided between layers of the same shape.
+
+### Added
+
+- `taper::gradcheck` — public finite-difference verification, applicable to your
+  own `Module`. Every differentiable operation in the crate is checked with it.
+- `taper::error::ShapeError` and `try_*` forms of the shape-critical operations
+  (`try_new`, `try_reshape`, `try_matmul`, `try_add`/`sub`/`mul`/`div`). The
+  panicking forms delegate to them, so the two cannot drift.
+- `taper::safetensors` — read and write the safetensors format, including
+  `F64`/`I64` narrowing on read and rejection of malformed files.
+- Strided tensors: `(storage, shape, stride, offset)`, making `transpose`,
+  `reshape` and `narrow` zero-copy views.
+- NumPy-rule broadcasting via `expand`, implemented as stride-0 views.
+- `DType` — narrow storage (`bf16`/`f16`/`i32`/`u8`) with `f32` computation.
+- `LayerNorm` and `BatchNorm2d`, the latter with running statistics.
+- `Module::buffers` — non-learnable state that is checkpointed but never
+  optimized.
+- `Dataset` trait, generic `DataLoader`, and `TensorDataset`, so training is no
+  longer restricted to MNIST.
+- `tape::no_grad` for inference; `Module::set_training` for train/eval.
+- `Trainer::load_checkpoint`, `save_safetensors`, `load_safetensors`.
+- Int4, BFloat16 and NF4 quantization, replacing `unimplemented!()`.
+- CI over five configurations: three SIMD paths and two BLAS vendors.
+
+### Changed
+
+- `backward` traverses only the operations its output depends on. Two
+  independent graphs on one tape no longer run each other's backward passes.
+- A poisoned lock no longer disables a tensor permanently.
+- `data()`/`data_mut()` assert dense `f32` storage; use `elements()` or
+  `to_vec()` for any layout or dtype.
+- `ReduceLROnPlateau` takes a `PlateauMode` enum rather than a `String`, and no
+  longer prints to stdout.
+- `Adam` and `AdamW` implement the `Optimizer` trait.
+- `Linear` uses He-uniform initialization (`sqrt(6/fan_in)`); the previous bound
+  gave a third of the intended variance.
+
+### Removed
+
+- `conv2d_direct_3x3` (unused, no autograd), `HistogramObserver`,
+  `ObserverManager`, `BasicBlock`, `QuantizationSchema`, `fma_f32_simd`, and the
+  `Int8Tensor::min_val` placeholder.
+
+### Known limitations
+
+- CPU only; the autograd tape is thread-local, so no data-parallel training.
+- No `Embedding`, attention, `GELU`/`SiLU` or recurrent layers — a transformer
+  cannot yet be expressed.
+- `Trainer` is classification-only (cross-entropy, accuracy).
+- Performance has not been benchmarked against other frameworks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "taper"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "approx",
  "blas-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,20 @@
 [package]
 name = "taper"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Vipul Vaibhaw <vaibhaw.vipul@gmail.com>"]
 build = "build.rs"
+description = "A lightweight neural network library with tape-based automatic differentiation, where every backward pass is verified against finite differences."
+license = "MIT"
+repository = "https://github.com/vaibhawvipul/taper"
+documentation = "https://docs.rs/taper"
+readme = "README.md"
+keywords = ["deep-learning", "autodiff", "neural-network", "machine-learning", "tensor"]
+categories = ["science", "algorithms"]
+# The MNIST download cache and benchmark scripts are not part of the library.
+# Patterns are anchored with a leading slash: a bare "data/" would also match
+# src/data/, which silently produced a package that would not compile.
+exclude = ["/data/", "/test_data/", "/*.py"]
 
 [dependencies]
 smallvec = "1.15.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # taper
 A lightweight neural network library in Rust with automatic differentiation.
 
+## Verified gradients
+
+Every differentiable operation is checked against finite differences, because a
+hand-written backward that is quietly wrong does not announce itself — the loss
+still falls while other layers compensate. The check is public, so it applies to
+your own layers too:
+
+```rust
+use taper::gradcheck;
+
+gradcheck::check(&[input.clone()], |t| my_layer.forward(&t[0]))?;
+```
+
+## Error handling
+
+Shape preconditions that data can violate have a fallible form; the panicking
+form delegates to it, so the two cannot disagree:
+
+```rust
+match a.try_matmul(&b) {
+    Ok(product) => /* ... */,
+    Err(e) => eprintln!("bad shapes: {e}"),
+}
+```
+
+A panic elsewhere does not permanently disable a tensor — its locks recover
+rather than staying poisoned.
+
 ## Features
 - Dynamic computational graph with tape-based autograd
 - SIMD-optimized tensor operations (AVX/SSE/NEON, with a scalar fallback)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,112 @@
+//! Recoverable errors from tensor operations.
+//!
+//! Most of this crate's preconditions are programmer errors — an internal
+//! invariant that a caller cannot influence — and those keep panicking, which
+//! is idiomatic. But shapes are frequently *data*-derived: a feature count read
+//! from a CSV header, a sequence length from a request. Aborting the process
+//! over one malformed input is not acceptable in a service, so every operation
+//! whose validity depends on shapes has a `try_` form returning [`ShapeError`].
+//!
+//! The panicking forms are thin wrappers over the fallible ones, so there is a
+//! single implementation and the two cannot drift apart.
+//!
+//! ```
+//! use taper::Tensor;
+//!
+//! // Recover instead of aborting.
+//! let malformed = Tensor::try_new(vec![1.0, 2.0, 3.0], &[2, 2]);
+//! assert!(malformed.is_err());
+//!
+//! let a = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
+//! let b = Tensor::new(vec![1.0; 6], &[3, 2]);
+//! match a.try_matmul(&b) {
+//!     Ok(product) => println!("{:?}", product.shape()),
+//!     Err(e) => eprintln!("bad request: {e}"),
+//! }
+//! ```
+
+use std::fmt;
+
+/// A shape precondition that a caller can plausibly hit with real data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShapeError {
+    /// A buffer's length does not match the shape it was given.
+    Length {
+        op: &'static str,
+        expected: usize,
+        got: usize,
+        shape: Vec<usize>,
+    },
+    /// Two shapes had to be equal and were not.
+    Mismatch {
+        op: &'static str,
+        lhs: Vec<usize>,
+        rhs: Vec<usize>,
+    },
+    /// Two shapes do not broadcast against each other.
+    NotBroadcastable {
+        op: &'static str,
+        lhs: Vec<usize>,
+        rhs: Vec<usize>,
+    },
+    /// An operation needed a particular rank.
+    Rank {
+        op: &'static str,
+        expected: &'static str,
+        got: Vec<usize>,
+    },
+    /// An index or range fell outside a dimension.
+    OutOfBounds {
+        op: &'static str,
+        dim: usize,
+        requested: usize,
+        limit: usize,
+    },
+    /// A dimension was zero where the operation needs a positive extent.
+    ZeroExtent {
+        op: &'static str,
+        what: &'static str,
+    },
+}
+
+impl fmt::Display for ShapeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // Wording is load-bearing: `expect` on these produces the panic
+            // messages the crate has always emitted.
+            ShapeError::Length {
+                op,
+                expected,
+                got,
+                shape,
+            } => write!(
+                f,
+                "{op}: {got} values do not fill shape {shape:?} ({expected} needed)"
+            ),
+            ShapeError::Mismatch { op, lhs, rhs } => {
+                write!(f, "{op}: shapes must match ({lhs:?} vs {rhs:?})")
+            }
+            ShapeError::NotBroadcastable { op, lhs, rhs } => {
+                write!(f, "{op}: shapes {lhs:?} and {rhs:?} do not broadcast")
+            }
+            ShapeError::Rank { op, expected, got } => {
+                write!(f, "{op}: expected {expected}, got shape {got:?}")
+            }
+            ShapeError::OutOfBounds {
+                op,
+                dim,
+                requested,
+                limit,
+            } => write!(
+                f,
+                "{op}: {requested} is out of range for dimension {dim} of length {limit}"
+            ),
+            ShapeError::ZeroExtent { op, what } => write!(f, "{op}: {what} must be non-zero"),
+        }
+    }
+}
+
+impl std::error::Error for ShapeError {}
+
+/// Shorthand for fallible tensor operations.
+pub type Result<T> = std::result::Result<T, ShapeError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use blas_src as _;
 
 pub mod activation;
 pub mod data;
+pub mod error;
 pub mod gemm;
 pub mod gradcheck;
 pub mod loss;
@@ -21,6 +22,7 @@ pub mod tape;
 pub mod tensor;
 pub mod train;
 
+pub use error::ShapeError;
 pub use gemm::{n, sgemm_rowmajor, t};
 pub use quantization::{QATConfig, QATManager, QuantizationConfig, QuantizationType};
 pub use tape::Tape;

--- a/src/loss.rs
+++ b/src/loss.rs
@@ -32,7 +32,7 @@ pub fn bce_loss(predictions: &Tensor, targets: &Tensor) -> Tensor {
         let n = p.len();
 
         Tape::push_binary_op(predictions, targets, &out, move || {
-            if let Some(gout) = out_clone.grad.read().unwrap().as_ref() {
+            if let Some(gout) = crate::tensor::read_recovering(&out_clone.grad).as_ref() {
                 let g = gout[0]; // scalar chain multiplier from upstream
 
                 let pdat = preds.elements();
@@ -187,7 +187,7 @@ pub fn cross_entropy_loss(logits: &Tensor, targets: &Tensor) -> Tensor {
         drop(t);
 
         Tape::push_unary_op(logits, &out, move || {
-            if let Some(g) = out_c.grad.read().expect("grad RwLock poisoned").as_ref() {
+            if let Some(g) = crate::tensor::read_recovering(&out_c.grad).as_ref() {
                 // scale by upstream scalar / batch
                 let scale = g[0] / b as f32;
                 let grad: Vec<f32> = base_grad.iter().map(|v| v * scale).collect();
@@ -242,7 +242,7 @@ pub fn cross_entropy_loss_onehot(logits: &Tensor, targets: &Tensor) -> Tensor {
         Tape::push_unary_op(logits, &loss, move || {
             // A read lock is enough here; taking the write lock serialized
             // backward passes against every concurrent reader for no reason.
-            if let Some(gloss) = loss_out.grad.read().expect("grad RwLock poisoned").as_ref() {
+            if let Some(gloss) = crate::tensor::read_recovering(&loss_out.grad).as_ref() {
                 // Gradient: (softmax - targets) * grad_loss / batch_size
                 let scale = gloss[0] / batch_size as f32;
                 let grad_data: Vec<f32> = base_grad.iter().map(|g| g * scale).collect();

--- a/src/nn.rs
+++ b/src/nn.rs
@@ -1008,12 +1008,12 @@ impl Tensor {
             // weights ever received a gradient.
             let parents: Vec<&Tensor> = tensors.iter().collect();
             crate::tape::Tape::push_op(&parents, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                if let Some(gout) = crate::tensor::read_recovering(&out.grad).as_ref() {
                     for (tensor, positions) in inputs.iter().zip(source_positions.iter()) {
                         if !tensor.requires_grad {
                             continue;
                         }
-                        let mut slot = tensor.grad.write().expect("grad RwLock poisoned");
+                        let mut slot = crate::tensor::write_recovering(&tensor.grad);
                         let gin = slot.get_or_insert_with(|| vec![0.0; tensor.numel()]);
                         for (local, &pos) in positions.iter().enumerate() {
                             gin[local] += gout[pos];

--- a/src/norm.rs
+++ b/src/norm.rs
@@ -17,6 +17,7 @@
 //! Both backwards are checked against finite differences in `tests/norm.rs`.
 
 use crate::tape::Tape;
+use crate::tensor::read_recovering;
 use crate::{Tensor, nn::Module, ops};
 
 /// The shared backward for a normalized group.
@@ -142,13 +143,7 @@ impl Module for LayerNorm {
             let out_t = output.clone();
 
             Tape::push_unary_op(input, &output, move || {
-                let Some(gout) = out_t
-                    .grad
-                    .read()
-                    .expect("grad RwLock poisoned")
-                    .as_ref()
-                    .cloned()
-                else {
+                let Some(gout) = read_recovering(&out_t.grad).as_ref().cloned() else {
                     return;
                 };
 
@@ -355,13 +350,7 @@ impl Module for BatchNorm2d {
             let training = self.training;
 
             Tape::push_unary_op(input, &output, move || {
-                let Some(gout) = out_t
-                    .grad
-                    .read()
-                    .expect("grad RwLock poisoned")
-                    .as_ref()
-                    .cloned()
-                else {
+                let Some(gout) = read_recovering(&out_t.grad).as_ref().cloned() else {
                     return;
                 };
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,3 +1,4 @@
+use crate::error::ShapeError;
 use crate::gemm::{TransFlag, n as no_trans, sgemm_rowmajor, t as trans};
 use crate::tensor::GemmLayout;
 use crate::{Tensor, tape::Tape};
@@ -25,8 +26,7 @@ use crate::tensor::simd;
 impl Add for &Tensor {
     type Output = Tensor;
     fn add(self, other: &Tensor) -> Tensor {
-        let (lhs, rhs) = broadcast_pair(self, other, "add");
-        elementwise_add(&lhs, &rhs)
+        self.try_add(other).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -36,15 +36,14 @@ impl Mul for &Tensor {
     // the multiplication itself, which clippy's heuristic cannot distinguish.
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, other: &Tensor) -> Tensor {
-        let (lhs, rhs) = broadcast_pair(self, other, "mul");
-        elementwise_mul(&lhs, &rhs)
+        self.try_mul(other).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
 // Helper function to accumulate gradients with SIMD
 #[inline]
 pub fn accumulate_grad(t: &Tensor, src: &[f32]) {
-    let mut slot = t.grad.write().expect("grad RwLock poisoned");
+    let mut slot = crate::tensor::write_recovering(&t.grad);
     let g = slot.get_or_insert_with(|| vec![0.0; t.numel()]);
     debug_assert_eq!(
         g.len(),
@@ -60,7 +59,7 @@ pub fn accumulate_grad(t: &Tensor, src: &[f32]) {
 
 #[inline]
 pub fn accumulate_grad_scaled(t: &Tensor, src: &[f32], scale: f32) {
-    let mut slot = t.grad.write().expect("grad RwLock poisoned");
+    let mut slot = crate::tensor::write_recovering(&t.grad);
     let g = slot.get_or_insert_with(|| vec![0.0; t.numel()]);
     debug_assert_eq!(
         g.len(),
@@ -85,18 +84,22 @@ pub fn accumulate_grad_scaled(t: &Tensor, src: &[f32], scale: f32) {
 /// only as three hand-written special cases (`add_broadcast`,
 /// `sub_broadcast_rows`, `div_broadcast_rows`).
 #[inline]
-fn broadcast_pair(a: &Tensor, b: &Tensor, op: &str) -> (Tensor, Tensor) {
+fn broadcast_pair(
+    a: &Tensor,
+    b: &Tensor,
+    op: &'static str,
+) -> crate::error::Result<(Tensor, Tensor)> {
     if a.shape() == b.shape() {
-        return (a.clone(), b.clone());
+        return Ok((a.clone(), b.clone()));
     }
-    let target = crate::tensor::broadcast_shape(a.shape(), b.shape()).unwrap_or_else(|| {
-        panic!(
-            "{op}: shapes {:?} and {:?} do not broadcast",
-            a.shape(),
-            b.shape()
-        )
-    });
-    (a.expand(&target), b.expand(&target))
+    let target = crate::tensor::broadcast_shape(a.shape(), b.shape()).ok_or(
+        ShapeError::NotBroadcastable {
+            op,
+            lhs: a.shape().to_vec(),
+            rhs: b.shape().to_vec(),
+        },
+    )?;
+    Ok((a.expand(&target), b.expand(&target)))
 }
 
 // Implement other trait combinations
@@ -147,14 +150,31 @@ impl Tensor {
     /// Fast matrix multiplication: [m,k] @ [k,n] -> [m,n]
     /// Fast matrix multiplication: [m,k] @ [k,n_out] -> [m,n_out]
     pub fn matmul(&self, other: &Tensor) -> Tensor {
-        assert_eq!(self.shape.len(), 2, "First tensor must be 2D");
-        assert_eq!(other.shape.len(), 2, "Second tensor must be 2D");
+        self.try_matmul(other).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Matrix product, reporting a shape problem instead of panicking.
+    pub fn try_matmul(&self, other: &Tensor) -> crate::error::Result<Tensor> {
+        for t in [self, other] {
+            if t.shape.len() != 2 {
+                return Err(ShapeError::Rank {
+                    op: "matmul",
+                    expected: "a 2D tensor",
+                    got: t.shape.to_vec(),
+                });
+            }
+        }
+        if self.shape[1] != other.shape[0] {
+            return Err(ShapeError::Mismatch {
+                op: "matmul: inner dimensions",
+                lhs: self.shape.to_vec(),
+                rhs: other.shape.to_vec(),
+            });
+        }
 
         let m = self.shape[0] as i32;
         let k = self.shape[1] as i32;
-        let k2 = other.shape[0] as i32;
         let n_out = other.shape[1] as i32;
-        assert_eq!(k, k2, "Inner dimensions must match: {} vs {}", k, k2);
 
         // A transposed view is already the layout BLAS wants under its trans
         // flag, so it feeds straight in — no materialization. Anything with a
@@ -193,7 +213,7 @@ impl Tensor {
             let b_shape = other.shape.clone();
 
             Tape::push_binary_op(self, other, &out, move || {
-                if let Some(gout_vec) = out_t.grad.read().unwrap().as_ref() {
+                if let Some(gout_vec) = crate::tensor::read_recovering(&out_t.grad).as_ref() {
                     let gout = &gout_vec[..];
 
                     // dA += dC * B^T   (m×k) = (m×n_out) * (n_out×k)
@@ -206,7 +226,7 @@ impl Tensor {
                         // operand read out of the graph needs a layout flag.
                         let b_op = b_t.packed_operand();
                         let b_store = b_op.storage();
-                        let mut slot = a_t.grad.write().expect("grad RwLock poisoned");
+                        let mut slot = crate::tensor::write_recovering(&a_t.grad);
                         let ga = slot.get_or_insert_with(|| vec![0.0; (m * k) as usize]);
                         sgemm_rowmajor(
                             no_trans(),
@@ -230,7 +250,7 @@ impl Tensor {
 
                         let a_op = a_t.packed_operand();
                         let a_store = a_op.storage();
-                        let mut slot = b_t.grad.write().expect("grad RwLock poisoned");
+                        let mut slot = crate::tensor::write_recovering(&b_t.grad);
                         let gb = slot.get_or_insert_with(|| vec![0.0; (kdim * n_out) as usize]);
                         sgemm_rowmajor(
                             trans_flag(&a_op, true),
@@ -249,7 +269,7 @@ impl Tensor {
             });
         }
 
-        out
+        Ok(out)
     }
 
     /// Create a random tensor with values from normal distribution
@@ -311,7 +331,7 @@ impl Tensor {
             let out = output.clone();
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().unwrap().as_ref() {
+                if let Some(gout) = crate::tensor::read_recovering(&out.grad).as_ref() {
                     let x = input.data();
                     let mut slot = input.grad.write().unwrap();
                     if slot.is_none() {
@@ -332,8 +352,7 @@ impl Tensor {
 impl Sub for &Tensor {
     type Output = Tensor;
     fn sub(self, other: &Tensor) -> Tensor {
-        let (lhs, rhs) = broadcast_pair(self, other, "sub");
-        elementwise_sub(&lhs, &rhs)
+        self.try_sub(other).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -362,8 +381,7 @@ impl Sub for Tensor {
 impl Div for &Tensor {
     type Output = Tensor;
     fn div(self, other: &Tensor) -> Tensor {
-        let (lhs, rhs) = broadcast_pair(self, other, "div");
-        elementwise_div(&lhs, &rhs)
+        self.try_div(other).unwrap_or_else(|e| panic!("{e}"))
     }
 }
 
@@ -409,7 +427,7 @@ fn elementwise_add(this: &Tensor, other: &Tensor) -> Tensor {
         let o = out.clone();
 
         Tape::push_binary_op(this, other, &out, move || {
-            if let Some(gout) = o.grad.read().unwrap().as_ref() {
+            if let Some(gout) = crate::tensor::read_recovering(&o.grad).as_ref() {
                 if a.requires_grad {
                     accumulate_grad(&a, gout);
                 }
@@ -442,13 +460,13 @@ fn elementwise_mul(this: &Tensor, other: &Tensor) -> Tensor {
         let o = out.clone();
 
         Tape::push_binary_op(this, other, &out, move || {
-            if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
+            if let Some(gout) = crate::tensor::read_recovering(&o.grad).as_ref() {
                 // d/da (a*b) = b, d/db (a*b) = a. Each branch used to size the
                 // gradient from the *other* operand's data and round-trip
                 // through two scratch buffers; fold it into one pass.
                 if a.requires_grad {
                     let bdat = b.elements();
-                    let mut slot = a.grad.write().expect("grad RwLock poisoned");
+                    let mut slot = crate::tensor::write_recovering(&a.grad);
                     let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
                     for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
                         *g += go * bv;
@@ -456,7 +474,7 @@ fn elementwise_mul(this: &Tensor, other: &Tensor) -> Tensor {
                 }
                 if b.requires_grad {
                     let adat = a.elements();
-                    let mut slot = b.grad.write().expect("grad RwLock poisoned");
+                    let mut slot = crate::tensor::write_recovering(&b.grad);
                     let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
                     for ((g, &go), &av) in gb.iter_mut().zip(gout.iter()).zip(adat.iter()) {
                         *g += go * av;
@@ -488,7 +506,7 @@ fn elementwise_sub(this: &Tensor, other: &Tensor) -> Tensor {
         let o = out.clone();
 
         Tape::push_binary_op(this, other, &out, move || {
-            if let Some(gout) = o.grad.read().unwrap().as_ref() {
+            if let Some(gout) = crate::tensor::read_recovering(&o.grad).as_ref() {
                 if a.requires_grad {
                     accumulate_grad(&a, gout);
                 }
@@ -521,11 +539,11 @@ fn elementwise_div(this: &Tensor, other: &Tensor) -> Tensor {
         let o = out.clone();
 
         Tape::push_binary_op(this, other, &out, move || {
-            if let Some(gout) = o.grad.read().expect("grad RwLock poisoned").as_ref() {
+            if let Some(gout) = crate::tensor::read_recovering(&o.grad).as_ref() {
                 // d/da (a/b) = 1/b, d/db (a/b) = -a/b²
                 if a.requires_grad {
                     let bdat = b.elements();
-                    let mut slot = a.grad.write().expect("grad RwLock poisoned");
+                    let mut slot = crate::tensor::write_recovering(&a.grad);
                     let ga = slot.get_or_insert_with(|| vec![0.0; a.numel()]);
                     for ((g, &go), &bv) in ga.iter_mut().zip(gout.iter()).zip(bdat.iter()) {
                         *g += go / bv;
@@ -534,7 +552,7 @@ fn elementwise_div(this: &Tensor, other: &Tensor) -> Tensor {
                 if b.requires_grad {
                     let adat = a.elements();
                     let bdat = b.elements();
-                    let mut slot = b.grad.write().expect("grad RwLock poisoned");
+                    let mut slot = crate::tensor::write_recovering(&b.grad);
                     let gb = slot.get_or_insert_with(|| vec![0.0; b.numel()]);
                     for (((g, &go), &av), &bv) in gb
                         .iter_mut()
@@ -549,4 +567,30 @@ fn elementwise_div(this: &Tensor, other: &Tensor) -> Tensor {
         });
     }
     out
+}
+
+impl Tensor {
+    /// Element-wise sum with broadcasting, reporting incompatible shapes.
+    pub fn try_add(&self, other: &Tensor) -> crate::error::Result<Tensor> {
+        let (lhs, rhs) = broadcast_pair(self, other, "add")?;
+        Ok(elementwise_add(&lhs, &rhs))
+    }
+
+    /// Element-wise difference with broadcasting, reporting incompatible shapes.
+    pub fn try_sub(&self, other: &Tensor) -> crate::error::Result<Tensor> {
+        let (lhs, rhs) = broadcast_pair(self, other, "sub")?;
+        Ok(elementwise_sub(&lhs, &rhs))
+    }
+
+    /// Element-wise product with broadcasting, reporting incompatible shapes.
+    pub fn try_mul(&self, other: &Tensor) -> crate::error::Result<Tensor> {
+        let (lhs, rhs) = broadcast_pair(self, other, "mul")?;
+        Ok(elementwise_mul(&lhs, &rhs))
+    }
+
+    /// Element-wise quotient with broadcasting, reporting incompatible shapes.
+    pub fn try_div(&self, other: &Tensor) -> crate::error::Result<Tensor> {
+        let (lhs, rhs) = broadcast_pair(self, other, "div")?;
+        Ok(elementwise_div(&lhs, &rhs))
+    }
 }

--- a/src/quantization/fake_quantize.rs
+++ b/src/quantization/fake_quantize.rs
@@ -9,6 +9,7 @@ use std::sync::RwLock;
 use super::config::{QuantizationConfig, QuantizationType};
 use super::observers::MinMaxObserver;
 use crate::Tensor;
+use crate::tensor::{read_recovering, write_recovering};
 
 /// Quantization parameters, refined as the observer sees more data.
 #[derive(Debug, Clone, Copy)]
@@ -46,13 +47,8 @@ impl Clone for FakeQuantize {
     fn clone(&self) -> Self {
         Self {
             quant_config: self.quant_config.clone(),
-            params: RwLock::new(*self.params.read().expect("qparams lock poisoned")),
-            observer: RwLock::new(
-                self.observer
-                    .read()
-                    .expect("observer lock poisoned")
-                    .clone(),
-            ),
+            params: RwLock::new(*read_recovering(&self.params)),
+            observer: RwLock::new(read_recovering(&self.observer).clone()),
             training: self.training,
             qmin: self.qmin,
             qmax: self.qmax,
@@ -108,10 +104,7 @@ impl FakeQuantize {
 
     /// Whether the observer has seen enough data to derive a scale.
     pub fn is_calibrated(&self) -> bool {
-        self.params
-            .read()
-            .expect("qparams lock poisoned")
-            .calibrated
+        read_recovering(&self.params).calibrated
     }
 
     /// Update quantization parameters based on observed data
@@ -126,13 +119,13 @@ impl FakeQuantize {
         }
 
         let (min_val, max_val) = {
-            let mut observer = self.observer.write().expect("observer lock poisoned");
+            let mut observer = write_recovering(&self.observer);
             observer.observe_slice(data);
             observer.range()
         };
         let (min_val, max_val) = Self::widen_degenerate(min_val, max_val);
 
-        let mut params = self.params.write().expect("qparams lock poisoned");
+        let mut params = write_recovering(&self.params);
         if self.symmetric {
             let max_abs = min_val.abs().max(max_val.abs());
             // A tensor of all zeros gives max_abs == 0; dividing by the
@@ -189,7 +182,7 @@ impl FakeQuantize {
         // is what makes the first forward pass produce a real scale instead of
         // reusing the placeholder 1.0.
         self.observe(&data);
-        let params = *self.params.read().expect("qparams lock poisoned");
+        let params = *read_recovering(&self.params);
 
         let mut result = vec![0.0; data.len()];
         match self.quant_config.quant_type {
@@ -212,12 +205,7 @@ impl FakeQuantize {
 
             // Use straight-through estimator: forward quantizes, backward passes through
             crate::tape::Tape::push_unary_op(input, &output, move || {
-                if let Some(grad_output) = output_clone
-                    .grad
-                    .read()
-                    .expect("grad RwLock poisoned")
-                    .as_ref()
-                {
+                if let Some(grad_output) = read_recovering(&output_clone.grad).as_ref() {
                     // STE: gradient passes through unchanged
                     crate::ops::accumulate_grad(&input_clone, grad_output);
                 }
@@ -259,15 +247,12 @@ impl FakeQuantize {
 
     /// Get current scale
     pub fn scale(&self) -> f32 {
-        self.params.read().expect("qparams lock poisoned").scale
+        read_recovering(&self.params).scale
     }
 
     /// Get current zero point
     pub fn zero_point(&self) -> i32 {
-        self.params
-            .read()
-            .expect("qparams lock poisoned")
-            .zero_point
+        read_recovering(&self.params).zero_point
     }
 
     /// Get quantization configuration

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -1,3 +1,4 @@
+use crate::error::ShapeError;
 use crate::{ops, quantization::QuantizationConfig, tape::Tape};
 use smallvec::SmallVec;
 use std::sync::{RwLockReadGuard, RwLockWriteGuard, atomic::Ordering};
@@ -441,6 +442,26 @@ impl std::ops::Deref for Elements<'_> {
     }
 }
 
+/// Take a read lock, recovering if a previous holder panicked.
+///
+/// A poisoned lock would otherwise disable a tensor permanently: every later
+/// access panics, so one bad request takes a parameter out of service for the
+/// life of the process. Recovery is sound here because the guarded value is a
+/// plain numeric buffer — there is no invariant a partial write could violate,
+/// only values that may be stale.
+#[inline]
+pub(crate) fn read_recovering<T>(lock: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    lock.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Take a write lock, recovering if a previous holder panicked. See
+/// [`read_recovering`].
+#[inline]
+pub(crate) fn write_recovering<T>(lock: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
+    lock.write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// How a 2D tensor's memory maps onto a GEMM operand.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GemmLayout {
@@ -650,7 +671,7 @@ impl Int8Tensor {
     }
 
     pub fn data(&self) -> std::sync::RwLockReadGuard<'_, Vec<i8>> {
-        self.data.read().expect("Int8Tensor data lock poisoned")
+        read_recovering(&self.data)
     }
 
     pub fn scale(&self) -> f32 {
@@ -685,7 +706,7 @@ impl Int4Tensor {
     }
 
     pub fn data(&self) -> std::sync::RwLockReadGuard<'_, Vec<u8>> {
-        self.data.read().expect("Int4Tensor data lock poisoned")
+        read_recovering(&self.data)
     }
 
     pub fn scale(&self) -> f32 {
@@ -720,7 +741,7 @@ impl Float16Tensor {
     }
 
     pub fn data(&self) -> std::sync::RwLockReadGuard<'_, Vec<u16>> {
-        self.data.read().expect("Float16Tensor data lock poisoned")
+        read_recovering(&self.data)
     }
 }
 
@@ -747,7 +768,7 @@ impl BFloat16Tensor {
     }
 
     pub fn data(&self) -> std::sync::RwLockReadGuard<'_, Vec<u16>> {
-        self.data.read().expect("BFloat16Tensor data lock poisoned")
+        read_recovering(&self.data)
     }
 }
 
@@ -772,7 +793,7 @@ impl NF4Tensor {
     }
 
     pub fn data(&self) -> std::sync::RwLockReadGuard<'_, Vec<u8>> {
-        self.data.read().expect("NF4Tensor data lock poisoned")
+        read_recovering(&self.data)
     }
 
     /// The absolute-maximum scale the 4-bit codes are normalized against.
@@ -782,16 +803,25 @@ impl NF4Tensor {
 }
 
 impl Tensor {
+    /// # Panics
+    /// If `data` does not exactly fill `shape`. Use [`Tensor::try_new`] when the
+    /// shape comes from data rather than from the program.
     pub fn new(data: Vec<f32>, shape: &[usize]) -> Self {
+        Self::try_new(data, shape).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Build a tensor, reporting a length mismatch instead of panicking.
+    pub fn try_new(data: Vec<f32>, shape: &[usize]) -> crate::error::Result<Self> {
         let expected: usize = shape.iter().product();
-        assert_eq!(
-            data.len(),
-            expected,
-            "Tensor::new: {} values do not fill shape {:?}",
-            data.len(),
-            shape
-        );
-        Tensor {
+        if data.len() != expected {
+            return Err(ShapeError::Length {
+                op: "Tensor::new",
+                expected,
+                got: data.len(),
+                shape: shape.to_vec(),
+            });
+        }
+        Ok(Tensor {
             data: Arc::new(RwLock::new(Storage::F32(data))),
             stride: contiguous_strides(shape),
             offset: 0,
@@ -799,7 +829,7 @@ impl Tensor {
             grad: Arc::new(RwLock::new(None)),
             requires_grad: false,
             tape_node: Arc::new(std::sync::atomic::AtomicUsize::new(crate::tape::NO_NODE)),
-        }
+        })
     }
 
     /// Total number of elements.
@@ -814,7 +844,7 @@ impl Tensor {
 
     /// The element type this tensor stores.
     pub fn dtype(&self) -> DType {
-        self.data.read().expect("data RwLock poisoned").dtype()
+        read_recovering(&self.data).dtype()
     }
 
     /// Build a tensor directly over a typed buffer.
@@ -856,7 +886,7 @@ impl Tensor {
             let out = output.clone();
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                if let Some(gout) = read_recovering(&out.grad).as_ref() {
                     ops::accumulate_grad(&input, gout);
                 }
             });
@@ -867,7 +897,7 @@ impl Tensor {
 
     /// Bytes this tensor's storage occupies.
     pub fn storage_bytes(&self) -> usize {
-        let storage = self.data.read().expect("data RwLock poisoned");
+        let storage = read_recovering(&self.data);
         storage.len() * storage.dtype().size_of()
     }
 
@@ -883,7 +913,7 @@ impl Tensor {
     /// Whether this tensor spans its entire backing buffer, so the raw slice
     /// from `data()` is exactly its logical elements in order.
     fn owns_whole_storage(&self) -> bool {
-        let storage = self.data.read().expect("data RwLock poisoned");
+        let storage = read_recovering(&self.data);
         self.offset == 0
             && self.is_contiguous()
             && storage.len() == self.numel()
@@ -914,7 +944,7 @@ impl Tensor {
     /// Callers must account for `offset` and `stride` themselves.
     #[inline]
     pub(crate) fn storage(&self) -> RwLockReadGuard<'_, Storage> {
-        self.data.read().expect("data RwLock poisoned")
+        read_recovering(&self.data)
     }
 
     /// How a 2D tensor maps onto a GEMM operand, if it maps at all.
@@ -943,7 +973,7 @@ impl Tensor {
     #[inline]
     pub fn elements(&self) -> Elements<'_> {
         if self.owns_whole_storage() {
-            Elements::Borrowed(F32Ref(self.data.read().expect("data RwLock poisoned")))
+            Elements::Borrowed(F32Ref(read_recovering(&self.data)))
         } else {
             Elements::Owned(self.to_vec())
         }
@@ -997,9 +1027,9 @@ impl Tensor {
             let target: SmallVec<[usize; 4]> = target.iter().copied().collect();
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                if let Some(gout) = read_recovering(&out.grad).as_ref() {
                     let src_strides = contiguous_strides(&src_shape);
-                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
+                    let mut slot = write_recovering(&input.grad);
                     let gin = slot.get_or_insert_with(|| vec![0.0; src_shape.iter().product()]);
 
                     // Every expanded position folds back onto the source
@@ -1064,9 +1094,9 @@ impl Tensor {
             let base_shape = self.shape.clone();
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                if let Some(gout) = read_recovering(&out.grad).as_ref() {
                     let base_strides = contiguous_strides(&base_shape);
-                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
+                    let mut slot = write_recovering(&input.grad);
                     let gin = slot.get_or_insert_with(|| vec![0.0; base_shape.iter().product()]);
 
                     // Walk the window's logical positions, shifting the sliced
@@ -1144,7 +1174,7 @@ impl Tensor {
     /// Walks the strides, so it is correct for any view; the contiguous case
     /// short-circuits to a plain clone.
     pub fn to_vec(&self) -> Vec<f32> {
-        let storage = self.data.read().expect("data RwLock poisoned");
+        let storage = read_recovering(&self.data);
         if self.is_dense(&storage) {
             return storage.to_f32_vec();
         }
@@ -1160,7 +1190,7 @@ impl Tensor {
     /// values `f32` could not represent exactly — which is what serialization
     /// needs.
     pub fn to_storage(&self) -> Storage {
-        let storage = self.data.read().expect("data RwLock poisoned");
+        let storage = read_recovering(&self.data);
         if self.is_dense(&storage) {
             return storage.clone();
         }
@@ -1195,7 +1225,7 @@ impl Tensor {
             let out = output.clone();
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
+                if let Some(gout) = read_recovering(&out.grad).as_ref() {
                     ops::accumulate_grad(&input, gout);
                 }
             });
@@ -1251,14 +1281,14 @@ impl Tensor {
     #[inline]
     pub fn data(&self) -> F32Ref<'_> {
         self.assert_dense_f32("data()");
-        F32Ref(self.data.read().expect("data RwLock poisoned"))
+        F32Ref(read_recovering(&self.data))
     }
 
     /// Mutable access to the raw backing slice. Same restriction as [`Tensor::data`].
     #[inline]
     pub fn data_mut(&self) -> F32Mut<'_> {
         self.assert_dense_f32("data_mut()");
-        F32Mut(self.data.write().expect("data RwLock poisoned"))
+        F32Mut(write_recovering(&self.data))
     }
 
     /// Read-only view of grad vector if it exists.
@@ -1267,20 +1297,20 @@ impl Tensor {
     /// as optimizer steps, which borrows it under the lock instead.
     #[inline]
     pub fn grad_ref(&self) -> Option<std::sync::Arc<Vec<f32>>> {
-        let g = self.grad.read().expect("grad RwLock poisoned");
+        let g = read_recovering(&self.grad);
         g.as_ref().map(|v| std::sync::Arc::new(v.clone()))
     }
 
     /// Borrow the gradient under the read lock, returning `None` if unset.
     #[inline]
     pub fn with_grad<R>(&self, f: impl FnOnce(&[f32]) -> R) -> Option<R> {
-        let g = self.grad.read().expect("grad RwLock poisoned");
+        let g = read_recovering(&self.grad);
         g.as_ref().map(|v| f(v))
     }
 
     /// Convenience: clone grads into a new non-requiring-grad Tensor
     pub fn grad(&self) -> Option<Arc<Tensor>> {
-        let g = self.grad.read().expect("grad RwLock poisoned");
+        let g = read_recovering(&self.grad);
         g.as_ref().map(|v| {
             let mut t = Tensor::new(v.clone(), &self.shape);
             t.requires_grad = false;
@@ -1292,7 +1322,7 @@ impl Tensor {
         // Gradients are sized by logical element count, which for a view is not
         // the length of its (shared, possibly larger) backing storage.
         let ones = vec![1.0; self.numel()];
-        *self.grad.write().expect("grad RwLock poisoned") = Some(ones);
+        *write_recovering(&self.grad) = Some(ones);
 
         // `NO_NODE` (not 0) marks a tensor that is not the output of a recorded
         // op — node ids are indices and legitimately start at 0.
@@ -1300,7 +1330,7 @@ impl Tensor {
     }
 
     pub fn zero_grad(&self) {
-        *self.grad.write().expect("grad RwLock poisoned") = None;
+        *write_recovering(&self.grad) = None;
     }
 
     /// Transpose a 2D tensor. This is a view: it swaps the shape and stride
@@ -1635,14 +1665,20 @@ impl Tensor {
     /// change. A non-contiguous view has to be packed first, since its logical
     /// order is not the order its elements sit in memory.
     pub fn reshape(&self, shape: &[usize]) -> Tensor {
+        self.try_reshape(shape).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reshape, reporting an element-count mismatch instead of panicking.
+    pub fn try_reshape(&self, shape: &[usize]) -> crate::error::Result<Tensor> {
         let total_elements: usize = shape.iter().product();
-        assert_eq!(
-            self.numel(),
-            total_elements,
-            "Cannot reshape tensor of size {} to shape {:?}",
-            self.numel(),
-            shape
-        );
+        if self.numel() != total_elements {
+            return Err(ShapeError::Length {
+                op: "reshape",
+                expected: total_elements,
+                got: self.numel(),
+                shape: shape.to_vec(),
+            });
+        }
 
         let mut output = if self.is_contiguous() {
             self.view_with(
@@ -1676,7 +1712,7 @@ impl Tensor {
             });
         }
 
-        output
+        Ok(output)
     }
 
     /// Flatten tensor starting from start_dim
@@ -2543,8 +2579,8 @@ impl Tensor {
             let out = output.clone();
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gcol) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
-                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
+                if let Some(gcol) = read_recovering(&out.grad).as_ref() {
+                    let mut slot = write_recovering(&input.grad);
                     let gin = slot.get_or_insert_with(|| vec![0.0; n * c * h_in * w_in]);
 
                     // Scatter-add: overlapping windows contribute to the same
@@ -2709,8 +2745,8 @@ impl Tensor {
             let axes = *axes;
 
             Tape::push_unary_op(self, &output, move || {
-                if let Some(gout) = out.grad.read().expect("grad RwLock poisoned").as_ref() {
-                    let mut slot = input.grad.write().expect("grad RwLock poisoned");
+                if let Some(gout) = read_recovering(&out.grad).as_ref() {
+                    let mut slot = write_recovering(&input.grad);
                     let gin = slot.get_or_insert_with(|| vec![0.0; d0 * d1 * d2 * d3]);
 
                     // Same index map as the forward pass, run in reverse.

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,165 @@
+//! Recoverable failure: shape problems reported as errors, and a panic in one
+//! thread not permanently disabling a tensor.
+
+use taper::Tensor;
+use taper::error::ShapeError;
+
+#[test]
+fn try_new_reports_a_length_mismatch() {
+    let err = Tensor::try_new(vec![1.0, 2.0, 3.0], &[2, 2]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ShapeError::Length {
+                expected: 4,
+                got: 3,
+                ..
+            }
+        ),
+        "{err:?}"
+    );
+    // The message a service would log.
+    assert!(err.to_string().contains("do not fill shape"), "{err}");
+}
+
+#[test]
+fn try_new_accepts_a_valid_shape() {
+    let t = Tensor::try_new(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]).unwrap();
+    assert_eq!(t.shape(), &[2, 2]);
+}
+
+#[test]
+fn try_reshape_reports_an_element_count_mismatch() {
+    let t = Tensor::new(vec![0.0; 6], &[2, 3]);
+    assert!(t.try_reshape(&[4, 2]).is_err());
+    assert!(t.try_reshape(&[3, 2]).is_ok());
+    assert!(t.try_reshape(&[6]).is_ok());
+}
+
+#[test]
+fn try_matmul_reports_bad_inner_dimensions() {
+    let a = Tensor::new(vec![0.0; 6], &[2, 3]);
+    let b = Tensor::new(vec![0.0; 8], &[4, 2]);
+
+    let err = a.try_matmul(&b).unwrap_err();
+    assert!(matches!(err, ShapeError::Mismatch { .. }), "{err:?}");
+
+    assert!(a.try_matmul(&Tensor::new(vec![0.0; 6], &[3, 2])).is_ok());
+}
+
+#[test]
+fn try_matmul_reports_a_bad_rank() {
+    let a = Tensor::new(vec![0.0; 8], &[2, 2, 2]);
+    let b = Tensor::new(vec![0.0; 4], &[2, 2]);
+
+    let err = a.try_matmul(&b).unwrap_err();
+    assert!(matches!(err, ShapeError::Rank { .. }), "{err:?}");
+}
+
+#[test]
+fn fallible_operators_report_incompatible_shapes() {
+    let a = Tensor::new(vec![0.0; 6], &[2, 3]);
+    let bad = Tensor::new(vec![0.0; 8], &[2, 4]);
+    let broadcastable = Tensor::new(vec![0.0; 3], &[3]);
+
+    for result in [
+        a.try_add(&bad),
+        a.try_sub(&bad),
+        a.try_mul(&bad),
+        a.try_div(&bad),
+    ] {
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ShapeError::NotBroadcastable { .. }),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("do not broadcast"), "{err}");
+    }
+
+    // And the compatible case still works through the same path.
+    assert_eq!(a.try_add(&broadcastable).unwrap().shape(), &[2, 3]);
+}
+
+/// The fallible and panicking forms share one implementation, so a shape the
+/// `try_` form accepts must not panic in the operator, and vice versa.
+#[test]
+fn the_two_forms_agree() {
+    let cases: &[(&[usize], &[usize])] = &[
+        (&[2, 3], &[2, 3]),
+        (&[2, 3], &[3]),
+        (&[2, 3], &[2, 1]),
+        (&[2, 3], &[2, 4]),
+        (&[2, 3], &[5]),
+    ];
+
+    for (lhs, rhs) in cases {
+        let a = Tensor::new(vec![1.0; lhs.iter().product()], lhs);
+        let b = Tensor::new(vec![1.0; rhs.iter().product()], rhs);
+
+        let fallible_ok = a.try_add(&b).is_ok();
+        let panicking_ok = std::panic::catch_unwind(|| {
+            let _ = &a + &b;
+        })
+        .is_ok();
+
+        assert_eq!(
+            fallible_ok, panicking_ok,
+            "try_add and `+` disagree on {lhs:?} + {rhs:?}"
+        );
+    }
+}
+
+/// A panic while a tensor's lock was held used to poison it: every later access
+/// panicked, so one bad request took a parameter out of service for the life of
+/// the process. The guarded value is a plain numeric buffer, so recovering
+/// cannot be unsound.
+#[test]
+fn a_panic_does_not_permanently_disable_a_tensor() {
+    let t = Tensor::new(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    let shared = t.clone();
+
+    // Panic while holding the write lock.
+    let poisoned = std::thread::spawn(move || {
+        let _guard = shared.data_mut();
+        panic!("simulated failure mid-operation");
+    })
+    .join();
+    assert!(poisoned.is_err(), "the worker was supposed to panic");
+
+    // The tensor is still usable from this thread.
+    assert_eq!(t.to_vec(), vec![1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(t.data()[0], 1.0);
+    t.data_mut()[0] = 9.0;
+    assert_eq!(t.to_vec()[0], 9.0);
+
+    // And it still participates in operations.
+    let doubled = &t + &t;
+    assert_eq!(doubled.to_vec()[0], 18.0);
+}
+
+#[test]
+fn a_panic_does_not_disable_a_tensors_gradient() {
+    let t = Tensor::new(vec![1.0, 2.0], &[2]).requires_grad();
+    let shared = t.clone();
+
+    let _ = std::thread::spawn(move || {
+        let _guard = shared.grad.write().unwrap();
+        panic!("simulated failure while updating a gradient");
+    })
+    .join();
+
+    // Reading and accumulating both still work.
+    assert!(t.grad_ref().is_none());
+    taper::ops::accumulate_grad(&t, &[1.0, 1.0]);
+    assert_eq!(t.grad_ref().unwrap().as_slice(), &[1.0, 1.0]);
+}
+
+#[test]
+fn shape_errors_are_std_errors() {
+    fn boxed() -> Result<Tensor, Box<dyn std::error::Error>> {
+        // `?` has to work through the standard error trait for these to be
+        // usable in ordinary application code.
+        Ok(Tensor::try_new(vec![1.0], &[2])?)
+    }
+    assert!(boxed().is_err());
+}


### PR DESCRIPTION
Steps two and three of moving to 5/10, after #19's gradient verification.

### Fallible API

Shape preconditions that *data* can violate now have a `try_` form returning
`ShapeError`: `try_new`, `try_reshape`, `try_matmul`, `try_add`/`sub`/`mul`/`div`.

The panicking forms delegate to the fallible ones, so there is a single
implementation — and a test asserts the two agree on the same shapes, since
duplicated validation is how they would silently diverge.

Preconditions a caller *cannot* influence still panic. Converting all 201 assert
sites would be a large breaking change for little gain; an internal rank
invariant is a bug, not a runtime condition.

### Lock poisoning

Every tensor access went through `.expect("poisoned")`. One panic while a lock
was held took that tensor out of service **for the life of the process** — in a
service, a single malformed request would permanently break a parameter.

Locks now recover. That is sound here because the guarded value is a plain
numeric buffer: there is no invariant a partial write could violate, only values
that may be stale. Tests poison a lock from another thread and confirm the tensor
still reads, writes, and participates in operations.

### Release prep

crates.io metadata, and a CHANGELOG that records the correctness fixes and states
the known limitations plainly (CPU-only, no transformer layers, classification-only
`Trainer`, unbenchmarked).

`cargo package` earned its keep: a bare `"data/"` exclude pattern also matched
`src/data/`, so the published crate would not have compiled. The patterns are
anchored now, and packaging verifies.

**I have not published.** Version is bumped to 0.2.0 and `cargo package` succeeds,
but `cargo publish` is irreversible and yours to run.

189 tests, clippy clean.